### PR TITLE
🐛 set labels on the final container image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,15 +16,14 @@ FROM --platform=${BUILDPLATFORM} docker.io/golang:1.23.4 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 
-LABEL org.opencontainers.image.source=https://github.com/kcp-dev/api-syncagent
-LABEL org.opencontainers.image.description="A Kubernetes agent to synchronize APIs and their objects between Kubernetes clusters and kcp"
-LABEL org.opencontainers.image.licenses=Apache-2.0
-
 WORKDIR /go/src/github.com/kcp-dev/api-syncagent
 COPY . .
 RUN GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} make clean api-syncagent
 
 FROM gcr.io/distroless/static-debian12:debug
+LABEL org.opencontainers.image.source=https://github.com/kcp-dev/api-syncagent
+LABEL org.opencontainers.image.description="A Kubernetes agent to synchronize APIs and their objects between Kubernetes clusters and kcp"
+LABEL org.opencontainers.image.licenses=Apache-2.0
 
 COPY --from=builder /go/src/github.com/kcp-dev/api-syncagent/_build/api-syncagent /usr/local/bin/api-syncagent
 


### PR DESCRIPTION
## Summary
No need to label the temporary builder image.

## Release Notes

```release-note
NONE
```
