### PR TITLE
:sparkles: Add kubeconfig-host-override and kubeconfig-ca-file-override flags

### DIFF
--- a/cmd/api-syncagent/options.go
+++ b/cmd/api-syncagent/options.go
@@ -61,6 +61,9 @@ type Options struct {
 	PublishedResourceSelectorString string
 	PublishedResourceSelector       labels.Selector
 
+	KubeconfigHostOverride   string
+	KubeconfigCAFileOverride string
+
 	LogOptions log.Options
 }
 
@@ -80,6 +83,8 @@ func (o *Options) AddFlags(flags *pflag.FlagSet) {
 	flags.StringVar(&o.APIExportRef, "apiexport-ref", o.APIExportRef, "name of the APIExport in kcp that this Sync Agent is powering")
 	flags.StringVar(&o.PublishedResourceSelectorString, "published-resource-selector", o.PublishedResourceSelectorString, "restrict this Sync Agent to only process PublishedResources matching this label selector (optional)")
 	flags.BoolVar(&o.EnableLeaderElection, "enable-leader-election", o.EnableLeaderElection, "whether to perform leader election")
+	flags.StringVar(&o.KubeconfigHostOverride, "kubeconfig-host-override", o.KubeconfigHostOverride, "Override the host configured in the local kubeconfig")
+	flags.StringVar(&o.KubeconfigCAFileOverride, "kubeconfig-ca-file-override", o.KubeconfigCAFileOverride, "Override the server CA file configured in the local kubeconfig")
 }
 
 func (o *Options) Validate() error {


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

Some more advanced deployment scenarios for kcp-api-syncagent may require overriding the host and CA used in the REST config for the local Kubernetes cluster.

This can be the case when an OIDC trust exists between two clusters in which one cluster should run the syncagent, but another cluster is the control plane to which objects should be synced from kcp. In those situations, we want to reuse the token discovered from the container filesystem and talk to a different server which also accepts our token.

## Related issue(s)

Fixes #

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
Add `--kubeconfig-host-override` and `--kubeconfig-ca-file-override` flags
```
