### PR TITLE
🌱 Reword "platform" to "kcp"

### DIFF
--- a/cmd/api-syncagent/options.go
+++ b/cmd/api-syncagent/options.go
@@ -35,10 +35,10 @@ type Options struct {
 	// work.
 	// KubeconfigFile string
 
-	// PlatformKubeconfig is the kubeconfig that gives access to kcp. This
+	// KcpKubeconfig is the kubeconfig that gives access to kcp. This
 	// kubeconfig's cluster URL has to point to the workspace where the APIExport
 	// referenced via APIExportRef lives.
-	PlatformKubeconfig string
+	KcpKubeconfig string
 
 	// Namespace is the namespace that the Sync Agent runs in.
 	Namespace string
@@ -49,7 +49,7 @@ type Options struct {
 
 	// AgentName can be used to give this Sync Agent instance a custom name. This name is used
 	// for the Sync Agent resource inside kcp. This value must not be changed after a Sync Agent
-	// has registered for the first time in the platform.
+	// has registered for the first time in kcp.
 	// If not given, defaults to "<service ref>-syncagent".
 	AgentName string
 
@@ -77,7 +77,7 @@ func NewOptions() *Options {
 func (o *Options) AddFlags(flags *pflag.FlagSet) {
 	o.LogOptions.AddPFlags(flags)
 
-	flags.StringVar(&o.PlatformKubeconfig, "platform-kubeconfig", o.PlatformKubeconfig, "kubeconfig file of kcp")
+	flags.StringVar(&o.KcpKubeconfig, "kcp-kubeconfig", o.KcpKubeconfig, "kubeconfig file of kcp")
 	flags.StringVar(&o.Namespace, "namespace", o.Namespace, "Kubernetes namespace the Sync Agent is running in")
 	flags.StringVar(&o.AgentName, "agent-name", o.AgentName, "name of this Sync Agent, must not be changed after the first run, can be left blank to auto-generate a name")
 	flags.StringVar(&o.APIExportRef, "apiexport-ref", o.APIExportRef, "name of the APIExport in kcp that this Sync Agent is powering")
@@ -108,8 +108,8 @@ func (o *Options) Validate() error {
 		errs = append(errs, errors.New("--apiexport-ref is required"))
 	}
 
-	if len(o.PlatformKubeconfig) == 0 {
-		errs = append(errs, errors.New("--platform-kubeconfig is required"))
+	if len(o.KcpKubeconfig) == 0 {
+		errs = append(errs, errors.New("--kcp-kubeconfig is required"))
 	}
 
 	if s := o.PublishedResourceSelectorString; len(s) > 0 {

--- a/deploy/crd/kcp.io/syncagent.kcp.io_publishedresources.yaml
+++ b/deploy/crd/kcp.io/syncagent.kcp.io_publishedresources.yaml
@@ -244,7 +244,7 @@ spec:
                         description: ConfigMap or Secret
                         type: string
                       origin:
-                        description: '"service" or "platform"'
+                        description: '"service" or "kcp"'
                         type: string
                       reference:
                         properties:

--- a/docs/README.md
+++ b/docs/README.md
@@ -17,10 +17,9 @@ The intended usecase follows roughly these steps:
    inside of kcp.
 4. The service owner uses the Sync Agent Helm chart (or similar deployment technique) to install the
    Sync Agent in their cluster.
-5. To actually make resources available in the platform, the service owner now has to create a
-   set of `PublishedResource` objects. The configuration happens from their point of view, meaning
-   they define how to publish a CRD to the platform, defining renaming rules and other projection
-   settings.
+5. To actually make resources available in kcp, the service owner now has to create a set of
+   `PublishedResource` objects. The configuration happens from their point of view, meaning they
+   define how to publish a CRD to kcp, defining renaming rules and other projection settings.
 6. Once a `PublishedResource` is created in the service cluster, the Sync Agent will pick it up,
    find the referenced CRD, convert/project this CRD into an `APIResourceSchema` (ARS) for kcp and
    then create the ARS in org workspace.
@@ -28,7 +27,7 @@ The intended usecase follows roughly these steps:
    `APIExport` in the org workspace. This APIExport can then be bound in the org workspace itself
    (or later any workspaces (depending on permissions)) and be used there.
 8. kcp automatically provides a virtual workspace for the `APIExport` and this is what the Sync Agent
-   then uses to watch all objects for the relevant resources in the platform (i.e. in all workspaces).
+   then uses to watch all objects for the relevant resources in kcp (i.e. in all workspaces).
 9. The Sync Agent will now begin to synchronize objects back and forth between the service cluster
    and kcp.
 
@@ -100,8 +99,8 @@ In addition to projecting (mapping) the GVK, the `PublishedResource` also contai
 rules, which influence how the local objects that the Sync Agent is creating are named.
 
 As a single Sync Agent serves a single service, the API group used in kcp is the same for all
-`PublishedResources`. It's the API group configured in the `APIExport` inside the platform (created
-in step 1 in the overview above).
+`PublishedResources`. It's the API group configured in the `APIExport` inside kcp (created in step 1
+in the overview above).
 
 To prevent chaos, `PublishedResources` are immutable: handling the case that a PR first wants to
 publish `kubermatic.k8c.io/v1 Cluster` and then suddenly `kubermatic.k8c.io/v1 User` resources would

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -73,7 +73,7 @@ syncAgent:
 
   # Required: Name of the Kubernetes Secret that contains a "kubeconfig" key, with the kubeconfig
   # provided by kcp to access it.
-  platformKubeconfig: kcp-kubeconfig
+  kcpKubeconfig: kcp-kubeconfig
 
   # Create additional RBAC on the service cluster. These rules depend somewhat on the Sync Agent
   # configuration, but the following two rules are very common. If you configure the Sync Agent to

--- a/internal/controller/apiexport/doc.go
+++ b/internal/controller/apiexport/doc.go
@@ -22,6 +22,6 @@ created by the accompanying controller in the Sync Agent.
 
 Note that for the time being, to prevent data loss, only new ARS will be added to
 the APIExport. Once an ARS is listed in the APIExport, it is supposed to remain
-until an administrator/other process performs garbage collection in the platform.
+until an administrator/other process performs garbage collection in kcp.
 */
 package apiexport

--- a/internal/controller/apiresourceschema/doc.go
+++ b/internal/controller/apiresourceschema/doc.go
@@ -26,7 +26,7 @@ with an editor and re-applied, it won't turn into the same ARS, as we cannot sim
 turn an ARS for a Pod into an ARS for a StorageClass.
 
 There is no extra cleanup procedure in either of the clusters when a PublishedResource
-is deleted. This is to prevent accidental data loss in the platform in case a
-service owner accidentally (and temporarily) removed a PublishedResource.
+is deleted. This is to prevent accidental data loss in kcp in case a service owner
+accidentally (and temporarily) removed a PublishedResource.
 */
 package apiresourceschema

--- a/internal/controller/sync/doc.go
+++ b/internal/controller/sync/doc.go
@@ -15,10 +15,9 @@ limitations under the License.
 */
 
 /*
-Package sync contains a controller that watches the APIExport we manage
-in the platform cluster. Once the virtual workspace URL for said APIExport
-is ready, the controller will begin to synchronize resources back and forth
-between the platform cluster (i.e. all relevant workspaces) and the service
-cluster.
+Package sync contains a controller that watches the APIExport we manage in kcp.
+Once the virtual workspace URL for said APIExport is ready, the controller will
+begin to synchronize resources back and forth between kcp (i.e. all relevant
+workspaces) and the service cluster.
 */
 package sync

--- a/internal/controller/syncmanager/doc.go
+++ b/internal/controller/syncmanager/doc.go
@@ -16,9 +16,8 @@ limitations under the License.
 
 /*
 Package syncmanager contains a controller that watches the APIExport we manage
-in the platform cluster. Once the virtual workspace URL for said APIExport
-is ready, the controller will begin to synchronize resources back and forth
-between the platform cluster (i.e. all relevant workspaces) and the service
-cluster.
+in kcp. Once the virtual workspace URL for said APIExport is ready, the
+controller will begin to synchronize resources back and forth between kcp
+(i.e. all relevant workspaces) and the service cluster.
 */
 package syncmanager

--- a/internal/projection/projection.go
+++ b/internal/projection/projection.go
@@ -34,7 +34,7 @@ func PublishedResourceSourceGVK(pubRes *syncagentv1alpha1.PublishedResource) sch
 
 // PublishedResourceProjectedGVK returns the effective GVK after the projection
 // rules have been applied according to the PublishedResource.
-func PublishedResourceProjectedGVK(pubRes *syncagentv1alpha1.PublishedResource, platformAPIGroup string) schema.GroupVersionKind {
+func PublishedResourceProjectedGVK(pubRes *syncagentv1alpha1.PublishedResource, kcpAPIGroup string) schema.GroupVersionKind {
 	apiVersion := pubRes.Spec.Resource.Version
 	kind := pubRes.Spec.Resource.Kind
 
@@ -49,7 +49,7 @@ func PublishedResourceProjectedGVK(pubRes *syncagentv1alpha1.PublishedResource, 
 	}
 
 	return schema.GroupVersionKind{
-		Group:   platformAPIGroup,
+		Group:   kcpAPIGroup,
 		Version: apiVersion,
 		Kind:    kind,
 	}

--- a/internal/sync/syncer.go
+++ b/internal/sync/syncer.go
@@ -152,7 +152,7 @@ func (s *ResourceSyncer) Process(ctx Context, remoteObj *unstructured.Unstructur
 		// status subresource even exists whether an update happens)
 		syncStatusBack: true,
 		// perform cleanup on the service cluster side when the source object
-		// in the platform is deleted
+		// in kcp is deleted
 		blockSourceDeletion: true,
 		// use the configured mutations from the PublishedResource
 		mutator: s.mutator,

--- a/internal/sync/syncer_related.go
+++ b/internal/sync/syncer_related.go
@@ -140,13 +140,13 @@ func (s *ResourceSyncer) processRelatedResource(log *zap.SugaredLogger, stateSto
 		},
 		// ConfigMaps and Secrets have no subresources
 		subresources: nil,
-		// only sync the status back if the object originates in the platform,
+		// only sync the status back if the object originates in kcp,
 		// as the service side should never have to rely on new status infos coming
-		// from the platform side
-		syncStatusBack: relRes.Origin == "platform",
+		// from the kcp side
+		syncStatusBack: relRes.Origin == "kcp",
 		// if the origin is on the remote side, we want to add a finalizer to make
 		// sure we can clean up properly
-		blockSourceDeletion: relRes.Origin == "platform",
+		blockSourceDeletion: relRes.Origin == "kcp",
 		// apply mutation rules configured for the related resource
 		mutator: mutation.NewMutator(nil), // relRes.Mutation
 	}

--- a/sdk/apis/syncagent/v1alpha1/published_resource.go
+++ b/sdk/apis/syncagent/v1alpha1/published_resource.go
@@ -165,7 +165,7 @@ type RelatedResourceSpec struct {
 	// The identifier must be an alphanumeric string.
 	Identifier string `json:"identifier"`
 
-	// "service" or "platform"
+	// "service" or "kcp"
 	Origin string `json:"origin"`
 
 	// ConfigMap or Secret


### PR DESCRIPTION
## Summary
Platform is a leftover from the codebase's previous home and is now kind of a confusing term. I was debating with myself whether a more generic term might be good, like "source", but ultimately the syncer expects the source not to be any kind of Kubernetes endpoint, but a kcp or at least kcp-like endpoint, so the concrete term "kcp" feels okay.

## Release Notes
```release-note
Reword "platform" to "kcp"
```
