### PR TITLE
:seedling: Update to Go 1.23.5 for builds and tests

### DIFF
--- a/.prow.yaml
+++ b/.prow.yaml
@@ -21,7 +21,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: ghcr.io/kcp-dev/infra/build:1.23.4-3
+        - image: ghcr.io/kcp-dev/infra/build:1.23.5-1
           command:
             - hack/ci/verify.sh
           resources:
@@ -37,7 +37,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: ghcr.io/kcp-dev/infra/build:1.23.4-3
+        - image: ghcr.io/kcp-dev/infra/build:1.23.5-1
           command:
             - make
             - lint
@@ -54,7 +54,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/containers/buildah:v1.30.0
+        - image: quay.io/containers/buildah:v1.38.0
           command:
             - hack/ci/build-image.sh
           env:
@@ -76,7 +76,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: ghcr.io/kcp-dev/infra/build:1.23.4-3
+        - image: ghcr.io/kcp-dev/infra/build:1.23.5-1
           command:
             - make
             - test

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM --platform=${BUILDPLATFORM} docker.io/golang:1.23.4 AS builder
+FROM --platform=${BUILDPLATFORM} docker.io/golang:1.23.5 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

This updates to Go 1.23.5 as preparation for a first 0.1.0 release.

## Related issue(s)

Fixes #

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
Container image is now built with Go 1.23.5
```
