### PR TITLE
✨ Label local objects with the agent name

### DIFF
--- a/cmd/api-syncagent/main.go
+++ b/cmd/api-syncagent/main.go
@@ -138,7 +138,7 @@ func run(ctx context.Context, log *zap.SugaredLogger, opts *Options) error {
 		return fmt.Errorf("failed to add apiexport controller: %w", err)
 	}
 
-	if err := syncmanager.Add(ctx, mgr, kcpCluster, kcpRestConfig, log, apiExport, opts.PublishedResourceSelector, opts.Namespace); err != nil {
+	if err := syncmanager.Add(ctx, mgr, kcpCluster, kcpRestConfig, log, apiExport, opts.PublishedResourceSelector, opts.Namespace, opts.AgentName); err != nil {
 		return fmt.Errorf("failed to add syncmanager controller: %w", err)
 	}
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -69,8 +69,12 @@ itself and a reference to the kubeconfig secret we just created.
 # Required: the name of the APIExport in kcp that this Sync Agent is supposed to serve.
 apiExportName: test.example.com
 
-# Required: This Agent's public name, purely for informational purposes.
-# If not set, defaults to the Helm release name.
+# Required: This Agent's public name, used to signal ownership over locally synced objects.
+# This value must be a valid Kubernetes label value, see
+# https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#syntax-and-character-set
+# for more information.
+# Changing this value after the fact will make the agent ignore previously created objects,
+# so beware and relabel if necessary.
 agentName: unique-test
 
 # Required: Name of the Kubernetes Secret that contains a "kubeconfig" key,

--- a/internal/controller/syncmanager/controller.go
+++ b/internal/controller/syncmanager/controller.go
@@ -70,6 +70,7 @@ type Reconciler struct {
 	discoveryClient *discovery.Client
 	prFilter        labels.Selector
 	stateNamespace  string
+	agentName       string
 
 	apiExport *kcpdevv1alpha1.APIExport
 
@@ -95,6 +96,7 @@ func Add(
 	apiExport *kcpdevv1alpha1.APIExport,
 	prFilter labels.Selector,
 	stateNamespace string,
+	agentName string,
 ) error {
 	reconciler := &Reconciler{
 		ctx:             ctx,
@@ -108,6 +110,7 @@ func Add(
 		discoveryClient: discovery.NewClient(localManager.GetClient()),
 		prFilter:        prFilter,
 		stateNamespace:  stateNamespace,
+		agentName:       agentName,
 	}
 
 	_, err := builder.ControllerManagedBy(localManager).
@@ -280,6 +283,7 @@ func (r *Reconciler) ensureSyncControllers(ctx context.Context, log *zap.Sugared
 			r.discoveryClient,
 			r.apiExport.Name,
 			r.stateNamespace,
+			r.agentName,
 			r.log,
 			numSyncWorkers,
 		)

--- a/internal/sync/syncer.go
+++ b/internal/sync/syncer.go
@@ -46,6 +46,8 @@ type ResourceSyncer struct {
 
 	mutator mutation.Mutator
 
+	agentName string
+
 	// newObjectStateStore is used for testing purposes
 	newObjectStateStore newObjectStateStoreFunc
 }
@@ -59,6 +61,7 @@ func NewResourceSyncer(
 	remoteAPIGroup string,
 	mutator mutation.Mutator,
 	stateNamespace string,
+	agentName string,
 ) (*ResourceSyncer, error) {
 	// create a dummy that represents the type used on the local service cluster
 	localGVK := projection.PublishedResourceSourceGVK(pubRes)
@@ -100,6 +103,7 @@ func NewResourceSyncer(
 		subresources:        subresources,
 		destDummy:           localDummy,
 		mutator:             mutator,
+		agentName:           agentName,
 		newObjectStateStore: newKubernetesStateStoreCreator(stateNamespace),
 	}, nil
 }
@@ -145,6 +149,8 @@ func (s *ResourceSyncer) Process(ctx Context, remoteObj *unstructured.Unstructur
 	stateStore := s.newObjectStateStore(sourceSide, destSide)
 
 	syncer := objectSyncer{
+		// The primary object should be labelled with the agent name.
+		agentName:    s.agentName,
 		subresources: s.subresources,
 		// use the projection and renaming rules configured in the PublishedResource
 		destCreator: s.createLocalObjectCreator(ctx),

--- a/internal/sync/syncer_related.go
+++ b/internal/sync/syncer_related.go
@@ -127,6 +127,8 @@ func (s *ResourceSyncer) processRelatedResource(log *zap.SugaredLogger, stateSto
 	}
 
 	syncer := objectSyncer{
+		// Related objects within kcp are not labelled with the agent name because it's unnecessary.
+		// agentName: "",
 		// use the same state store as we used for the main resource, to keep everything contained
 		// in one place, on the service cluster side
 		stateStore: stateStore,

--- a/internal/sync/syncer_test.go
+++ b/internal/sync/syncer_test.go
@@ -182,6 +182,7 @@ func TestSyncerProcessingSingleResourceWithoutStatus(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "testcluster-my-test-thing",
 					Labels: map[string]string{
+						agentNameLabel:             "textor-the-doctor",
 						remoteObjectClusterLabel:   "testcluster",
 						remoteObjectNamespaceLabel: "",
 						remoteObjectNameLabel:      "my-test-thing",
@@ -208,6 +209,7 @@ func TestSyncerProcessingSingleResourceWithoutStatus(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "testcluster-my-test-thing",
 					Labels: map[string]string{
+						agentNameLabel:             "textor-the-doctor",
 						remoteObjectClusterLabel:   "testcluster",
 						remoteObjectNamespaceLabel: "",
 						remoteObjectNameLabel:      "my-test-thing",
@@ -255,6 +257,7 @@ func TestSyncerProcessingSingleResourceWithoutStatus(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "testcluster-my-test-thing",
 					Labels: map[string]string{
+						agentNameLabel:             "textor-the-doctor",
 						remoteObjectClusterLabel:   "testcluster",
 						remoteObjectNamespaceLabel: "",
 						remoteObjectNameLabel:      "my-test-thing",
@@ -312,6 +315,7 @@ func TestSyncerProcessingSingleResourceWithoutStatus(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "testcluster-my-test-thing",
 					Labels: map[string]string{
+						agentNameLabel:             "textor-the-doctor",
 						remoteObjectClusterLabel:   "testcluster",
 						remoteObjectNamespaceLabel: "",
 						remoteObjectNameLabel:      "my-test-thing",
@@ -348,6 +352,7 @@ func TestSyncerProcessingSingleResourceWithoutStatus(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "testcluster-my-test-thing",
 					Labels: map[string]string{
+						agentNameLabel:             "textor-the-doctor",
 						remoteObjectClusterLabel:   "testcluster",
 						remoteObjectNamespaceLabel: "",
 						remoteObjectNameLabel:      "my-test-thing",
@@ -374,6 +379,7 @@ func TestSyncerProcessingSingleResourceWithoutStatus(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "testcluster-my-test-thing",
 					Labels: map[string]string{
+						agentNameLabel:             "textor-the-doctor",
 						remoteObjectClusterLabel:   "testcluster",
 						remoteObjectNamespaceLabel: "",
 						remoteObjectNameLabel:      "my-test-thing",
@@ -410,6 +416,7 @@ func TestSyncerProcessingSingleResourceWithoutStatus(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "testcluster-my-test-thing",
 					Labels: map[string]string{
+						agentNameLabel:             "textor-the-doctor",
 						remoteObjectClusterLabel:   "testcluster",
 						remoteObjectNamespaceLabel: "",
 						remoteObjectNameLabel:      "my-test-thing",
@@ -436,6 +443,7 @@ func TestSyncerProcessingSingleResourceWithoutStatus(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "testcluster-my-test-thing",
 					Labels: map[string]string{
+						agentNameLabel:             "textor-the-doctor",
 						remoteObjectClusterLabel:   "testcluster",
 						remoteObjectNamespaceLabel: "",
 						remoteObjectNameLabel:      "my-test-thing",
@@ -484,6 +492,7 @@ func TestSyncerProcessingSingleResourceWithoutStatus(t *testing.T) {
 						"existing-annotation": "annotation-value",
 					},
 					Labels: map[string]string{
+						agentNameLabel:             "textor-the-doctor",
 						remoteObjectClusterLabel:   "testcluster",
 						remoteObjectNamespaceLabel: "",
 						remoteObjectNameLabel:      "my-test-thing",
@@ -525,6 +534,7 @@ func TestSyncerProcessingSingleResourceWithoutStatus(t *testing.T) {
 						"new-annotation":      "hei-verden",
 					},
 					Labels: map[string]string{
+						agentNameLabel:             "textor-the-doctor",
 						remoteObjectClusterLabel:   "testcluster",
 						remoteObjectNamespaceLabel: "",
 						remoteObjectNameLabel:      "my-test-thing",
@@ -564,6 +574,7 @@ func TestSyncerProcessingSingleResourceWithoutStatus(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "testcluster-my-test-thing",
 					Labels: map[string]string{
+						agentNameLabel:             "textor-the-doctor",
 						remoteObjectClusterLabel:   "testcluster",
 						remoteObjectNamespaceLabel: "",
 						remoteObjectNameLabel:      "my-test-thing",
@@ -591,6 +602,7 @@ func TestSyncerProcessingSingleResourceWithoutStatus(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "testcluster-my-test-thing",
 					Labels: map[string]string{
+						agentNameLabel:             "textor-the-doctor",
 						remoteObjectClusterLabel:   "testcluster",
 						remoteObjectNamespaceLabel: "",
 						remoteObjectNameLabel:      "my-test-thing",
@@ -636,6 +648,7 @@ func TestSyncerProcessingSingleResourceWithoutStatus(t *testing.T) {
 						"prevent-instant-deletion-in-tests",
 					},
 					Labels: map[string]string{
+						agentNameLabel:             "textor-the-doctor",
 						remoteObjectClusterLabel:   "testcluster",
 						remoteObjectNamespaceLabel: "",
 						remoteObjectNameLabel:      "my-test-thing",
@@ -667,6 +680,7 @@ func TestSyncerProcessingSingleResourceWithoutStatus(t *testing.T) {
 					},
 					DeletionTimestamp: &nonEmptyTime,
 					Labels: map[string]string{
+						agentNameLabel:             "textor-the-doctor",
 						remoteObjectClusterLabel:   "testcluster",
 						remoteObjectNamespaceLabel: "",
 						remoteObjectNameLabel:      "my-test-thing",
@@ -748,6 +762,7 @@ func TestSyncerProcessingSingleResourceWithoutStatus(t *testing.T) {
 					},
 					DeletionTimestamp: &nonEmptyTime,
 					Labels: map[string]string{
+						agentNameLabel:             "textor-the-doctor",
 						remoteObjectClusterLabel:   "testcluster",
 						remoteObjectNamespaceLabel: "",
 						remoteObjectNameLabel:      "my-test-thing",
@@ -778,6 +793,7 @@ func TestSyncerProcessingSingleResourceWithoutStatus(t *testing.T) {
 					},
 					DeletionTimestamp: &nonEmptyTime,
 					Labels: map[string]string{
+						agentNameLabel:             "textor-the-doctor",
 						remoteObjectClusterLabel:   "testcluster",
 						remoteObjectNamespaceLabel: "",
 						remoteObjectNameLabel:      "my-test-thing",
@@ -809,6 +825,7 @@ func TestSyncerProcessingSingleResourceWithoutStatus(t *testing.T) {
 				testcase.remoteAPIGroup,
 				nil,
 				stateNamespace,
+				"textor-the-doctor",
 			)
 			if err != nil {
 				t.Fatalf("Failed to create syncer: %v", err)
@@ -970,6 +987,7 @@ func TestSyncerProcessingSingleResourceWithStatus(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "testcluster-my-test-thing",
 					Labels: map[string]string{
+						agentNameLabel:             "textor-the-doctor",
 						remoteObjectClusterLabel:   "testcluster",
 						remoteObjectNamespaceLabel: "",
 						remoteObjectNameLabel:      "my-test-thing",
@@ -1002,6 +1020,7 @@ func TestSyncerProcessingSingleResourceWithStatus(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "testcluster-my-test-thing",
 					Labels: map[string]string{
+						agentNameLabel:             "textor-the-doctor",
 						remoteObjectClusterLabel:   "testcluster",
 						remoteObjectNamespaceLabel: "",
 						remoteObjectNameLabel:      "my-test-thing",
@@ -1041,6 +1060,7 @@ func TestSyncerProcessingSingleResourceWithStatus(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "testcluster-my-test-thing",
 					Labels: map[string]string{
+						agentNameLabel:             "textor-the-doctor",
 						remoteObjectClusterLabel:   "testcluster",
 						remoteObjectNamespaceLabel: "",
 						remoteObjectNameLabel:      "my-test-thing",
@@ -1073,6 +1093,7 @@ func TestSyncerProcessingSingleResourceWithStatus(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "testcluster-my-test-thing",
 					Labels: map[string]string{
+						agentNameLabel:             "textor-the-doctor",
 						remoteObjectClusterLabel:   "testcluster",
 						remoteObjectNamespaceLabel: "",
 						remoteObjectNameLabel:      "my-test-thing",
@@ -1106,6 +1127,7 @@ func TestSyncerProcessingSingleResourceWithStatus(t *testing.T) {
 				testcase.remoteAPIGroup,
 				nil,
 				stateNamespace,
+				"textor-the-doctor",
 			)
 			if err != nil {
 				t.Fatalf("Failed to create syncer: %v", err)

--- a/internal/sync/types.go
+++ b/internal/sync/types.go
@@ -16,6 +16,8 @@ limitations under the License.
 
 package sync
 
+import ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+
 const (
 	// deletionFinalizer is the finalizer put on remote objects to prevent
 	// them from being deleted before the local objects can be cleaned up.
@@ -31,6 +33,10 @@ const (
 
 	remoteObjectWorkspacePathAnnotation = "syncagent.kcp.io/remote-object-workspace-path"
 
+	// agentNameLabel contains the Sync Agent's name and is used to allow multiple Sync Agents
+	// on the same service cluster, syncing *the same* API to different kcp's.
+	agentNameLabel = "syncagent.kcp.io/agent-name"
+
 	// objectStateLabelName is put on object state Secrets to allow for easier mass deletions
 	// if ever necessary.
 	objectStateLabelName = "syncagent.kcp.io/object-state"
@@ -45,3 +51,7 @@ const (
 	// metadata of the related object.
 	relatedObjectAnnotationPrefix = "related-resources.syncagent.kcp.io/"
 )
+
+func OwnedBy(obj ctrlruntimeclient.Object, agentName string) bool {
+	return obj.GetLabels()[agentNameLabel] == agentName
+}


### PR DESCRIPTION
## Summary
If two or more Sync Agents work on the same local cluster (but each talking to its own kcp), _and_ they both serve the same local API (i.e. there are 2 PublishedResources that describe the same local API), they will get confused over each other's objects. When Agent 1 syncs an object from kcp 1 to the local cluster, Agent 2 might think it own it. The severity of this issue also depends on object naming (if for example the kcp cluster names are included in the local object names, for example as namespaces, then a collision is less likely since cluster names should be globally unique).

To improve the situation, this PR uses the already existing agent name to label local objects, declaring ownership over them. This does not mean 2 PublishedResources can now lead to conflicts (object A in kcp 1 and object B in kcp 2 both getting synced down into the same local object), that is still forbidden. This PR is more about preventing accidental overlaps, where the Agent by accident reconciles the wrong objects.

## Related issue(s)
Fixes #13

## Release Notes
```release-note
Label local objects with the agent name
```
