### PR TITLE
:sparkles: Add GoReleaser config and Release GitHub Action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,11 +3,11 @@ name: goreleaser
 on:
   pull_request:
     paths:
-    - .github/workflows/release.yml
-    - .goreleaser.yaml
+      - .github/workflows/release.yml
+      - .goreleaser.yaml
   push:
     tags:
-    - 'v*'
+      - 'v*'
 
 permissions:
   contents: read
@@ -31,6 +31,9 @@ jobs:
     
       - name: Delete non-semver tags
         run: 'git tag -d $(git tag -l | grep -v "^v")'
+      
+      - name: Set LDFLAGS
+        run: echo LDFLAGS="$(make ldflags)" >> $GITHUB_ENV
     
       - name: Run GoReleaser on tag
         if: github.event_name != 'pull_request'
@@ -53,7 +56,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     
       - uses: actions/upload-artifact@v4
-        if: ${{ always() }}
+        if: github.event_name == 'pull_request'
         with:
           name: binaries
           path: dist/*.tar.gz

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,59 @@
+name: goreleaser
+
+on:
+  pull_request:
+    paths:
+    - .github/workflows/release.yml
+    - .goreleaser.yaml
+  push:
+    tags:
+    - 'v*'
+
+permissions:
+  contents: read
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+    
+      - uses: actions/setup-go@v5
+        with:
+          go-version: v1.22.10
+    
+      - name: Delete non-semver tags
+        run: 'git tag -d $(git tag -l | grep -v "^v")'
+    
+      - name: Run GoReleaser on tag
+        if: github.event_name != 'pull_request'
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          distribution: goreleaser
+          version: latest
+          args: release --timeout 60m
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    
+      - name: Run GoReleaser on pull request
+        if: github.event_name == 'pull_request'
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          distribution: goreleaser
+          version: latest
+          args: release --timeout 60m --snapshot
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    
+      - uses: actions/upload-artifact@v4
+        if: ${{ always() }}
+        with:
+          name: binaries
+          path: dist/*.tar.gz

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /_build/
+/dist/
 /_tools/
 /vendor/
 /.kcp.e2e/

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,37 @@
+# Copyright 2025 The KCP Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+builds:
+  - id: "api-syncagent"
+    main: ./cmd/api-syncagent
+    binary: api-syncagent
+    ldflags:
+      - "{{ .Env.LDFLAGS }}"
+    goos:
+      - linux
+      - darwin
+    goarch:
+      - amd64
+      - arm64
+    env:
+      - CGO_ENABLED=0
+
+archives:
+  - id: api-syncagent
+    builds:
+      - api-syncagent
+
+release:
+  draft: true
+  mode: keep-existing

--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,9 @@ GOOS ?= $(shell go env GOOS)
 .PHONY: all
 all: build test
 
+ldflags:
+	@echo $(LDFLAGS)
+
 .PHONY: build
 build: $(CMD)
 


### PR DESCRIPTION
## Summary

This PR adds:

- GoReleaser config based on [the kcp's GoRelease config](https://github.com/kcp-dev/kcp/blob/dfcda9f9ec7922dd7360f98811b1025b2542a8d2/.goreleaser.yaml)
- Release GitHub action based on [the kcp's release GH action](https://github.com/kcp-dev/kcp/blob/dfcda9f9ec7922dd7360f98811b1025b2542a8d2/.github/workflows/goreleaser.yml)

The api-syncagent's GH action uses `actions/upload-artifact@v4` instead of `cytopia/upload-artifact-retry-action@v0.1.7` as the latter is unmaintained (see https://github.com/kcp-dev/kcp/issues/3309).

## Release Notes
```release-note
NONE
```

/assign @xrstf @mjudeikis 