### PR TITLE
🐛 Handle long object names

### DIFF
--- a/internal/crypto/hash.go
+++ b/internal/crypto/hash.go
@@ -1,0 +1,51 @@
+/*
+Copyright 2025 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package crypto
+
+import (
+	"crypto/sha1"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+)
+
+func Hash(data any) string {
+	hash := sha1.New()
+
+	var err error
+	switch asserted := data.(type) {
+	case string:
+		_, err = hash.Write([]byte(asserted))
+	case []byte:
+		_, err = hash.Write(asserted)
+	default:
+		err = json.NewEncoder(hash).Encode(data)
+	}
+
+	if err != nil {
+		// This is not something that should ever happen at runtime and is also not
+		// something we can really gracefully handle, so crashing and restarting might
+		// be a good way to signal the service owner that something is up.
+		panic(fmt.Sprintf("Failed to hash: %v", err))
+	}
+
+	return hex.EncodeToString(hash.Sum(nil))
+}
+
+func ShortHash(data any) string {
+	return Hash(data)[:20]
+}

--- a/internal/sync/state_store.go
+++ b/internal/sync/state_store.go
@@ -20,8 +20,9 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/kcp-dev/api-syncagent/internal/crypto"
 	"github.com/kcp-dev/logicalcluster/v3"
+
+	"github.com/kcp-dev/api-syncagent/internal/crypto"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -82,7 +83,9 @@ func (op *objectStateStore) Put(obj *unstructured.Unstructured, clusterName logi
 
 func (op *objectStateStore) snapshotObject(obj *unstructured.Unstructured, subresources []string) (string, error) {
 	obj = obj.DeepCopy()
-	obj = stripMetadata(obj)
+	if err := stripMetadata(obj); err != nil {
+		return "", err
+	}
 
 	// besides metadata, we also do not care about the object's subresources
 	data := obj.UnstructuredContent()

--- a/internal/sync/syncer.go
+++ b/internal/sync/syncer.go
@@ -165,6 +165,10 @@ func (s *ResourceSyncer) Process(ctx Context, remoteObj *unstructured.Unstructur
 		mutator: s.mutator,
 		// make sure the syncer can remember the current state of any object
 		stateStore: stateStore,
+		// For the main resource, we need to store metadata on the destination copy
+		// (i.e. on the service cluster), so that the original and copy are linked
+		// together and can be found.
+		metadataOnDestination: true,
 	}
 
 	requeue, err = syncer.Sync(log, sourceSide, destSide)

--- a/internal/sync/syncer_related.go
+++ b/internal/sync/syncer_related.go
@@ -151,6 +151,8 @@ func (s *ResourceSyncer) processRelatedResource(log *zap.SugaredLogger, stateSto
 		blockSourceDeletion: relRes.Origin == "kcp",
 		// apply mutation rules configured for the related resource
 		mutator: mutation.NewMutator(relRes.Mutation),
+		// we never want to store sync-related metadata inside kcp
+		metadataOnDestination: false,
 	}
 
 	requeue, err = syncer.Sync(log, sourceSide, destSide)

--- a/internal/sync/syncer_test.go
+++ b/internal/sync/syncer_test.go
@@ -182,17 +182,19 @@ func TestSyncerProcessingSingleResourceWithoutStatus(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "testcluster-my-test-thing",
 					Labels: map[string]string{
-						agentNameLabel:             "textor-the-doctor",
-						remoteObjectClusterLabel:   "testcluster",
-						remoteObjectNamespaceLabel: "",
-						remoteObjectNameLabel:      "my-test-thing",
+						agentNameLabel:            "textor-the-doctor",
+						remoteObjectClusterLabel:  "testcluster",
+						remoteObjectNameHashLabel: "c346c8ceb5d104cc783d09b95e8ea7032c190948",
+					},
+					Annotations: map[string]string{
+						remoteObjectNameAnnotation: "my-test-thing",
 					},
 				},
 				Spec: dummyv1alpha1.ThingSpec{
 					Username: "Colonel Mustard",
 				},
 			}),
-			existingState: `{"apiVersion":"remote.example.corp/v1alpha1","kind":"RemoteThing","metadata":{"annotations":{},"name":"my-test-thing"},"spec":{"username":"Colonel Mustard"}}`,
+			existingState: `{"apiVersion":"remote.example.corp/v1alpha1","kind":"RemoteThing","metadata":{"name":"my-test-thing"},"spec":{"username":"Colonel Mustard"}}`,
 
 			expectedRemoteObject: newUnstructured(&dummyv1alpha1.Thing{
 				ObjectMeta: metav1.ObjectMeta{
@@ -209,17 +211,19 @@ func TestSyncerProcessingSingleResourceWithoutStatus(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "testcluster-my-test-thing",
 					Labels: map[string]string{
-						agentNameLabel:             "textor-the-doctor",
-						remoteObjectClusterLabel:   "testcluster",
-						remoteObjectNamespaceLabel: "",
-						remoteObjectNameLabel:      "my-test-thing",
+						agentNameLabel:            "textor-the-doctor",
+						remoteObjectClusterLabel:  "testcluster",
+						remoteObjectNameHashLabel: "c346c8ceb5d104cc783d09b95e8ea7032c190948",
+					},
+					Annotations: map[string]string{
+						remoteObjectNameAnnotation: "my-test-thing",
 					},
 				},
 				Spec: dummyv1alpha1.ThingSpec{
 					Username: "Colonel Mustard",
 				},
 			}),
-			expectedState: `{"apiVersion":"remote.example.corp/v1alpha1","kind":"RemoteThing","metadata":{"annotations":{},"name":"my-test-thing"},"spec":{"username":"Colonel Mustard"}}`,
+			expectedState: `{"apiVersion":"remote.example.corp/v1alpha1","kind":"RemoteThing","metadata":{"name":"my-test-thing"},"spec":{"username":"Colonel Mustard"}}`,
 		},
 
 		/////////////////////////////////////////////////////////////////////////////////
@@ -257,17 +261,19 @@ func TestSyncerProcessingSingleResourceWithoutStatus(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "testcluster-my-test-thing",
 					Labels: map[string]string{
-						agentNameLabel:             "textor-the-doctor",
-						remoteObjectClusterLabel:   "testcluster",
-						remoteObjectNamespaceLabel: "",
-						remoteObjectNameLabel:      "my-test-thing",
+						agentNameLabel:            "textor-the-doctor",
+						remoteObjectClusterLabel:  "testcluster",
+						remoteObjectNameHashLabel: "c346c8ceb5d104cc783d09b95e8ea7032c190948",
+					},
+					Annotations: map[string]string{
+						remoteObjectNameAnnotation: "my-test-thing",
 					},
 				},
 				Spec: dummyv1alpha1.ThingSpec{
 					Username: "Colonel Mustard",
 				},
 			}),
-			expectedState: `{"apiVersion":"remote.example.corp/v1alpha1","kind":"RemoteThing","metadata":{"annotations":{},"name":"my-test-thing"},"spec":{"username":"Colonel Mustard"}}`,
+			expectedState: `{"apiVersion":"remote.example.corp/v1alpha1","kind":"RemoteThing","metadata":{"name":"my-test-thing"},"spec":{"username":"Colonel Mustard"}}`,
 		},
 
 		/////////////////////////////////////////////////////////////////////////////////
@@ -315,17 +321,19 @@ func TestSyncerProcessingSingleResourceWithoutStatus(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "testcluster-my-test-thing",
 					Labels: map[string]string{
-						agentNameLabel:             "textor-the-doctor",
-						remoteObjectClusterLabel:   "testcluster",
-						remoteObjectNamespaceLabel: "",
-						remoteObjectNameLabel:      "my-test-thing",
+						agentNameLabel:            "textor-the-doctor",
+						remoteObjectClusterLabel:  "testcluster",
+						remoteObjectNameHashLabel: "c346c8ceb5d104cc783d09b95e8ea7032c190948",
+					},
+					Annotations: map[string]string{
+						remoteObjectNameAnnotation: "my-test-thing",
 					},
 				},
 				Spec: dummyv1alpha1.ThingSpec{
 					Username: "Colonel Mustard",
 				},
 			}),
-			expectedState: `{"apiVersion":"remote.example.corp/v1alpha1","kind":"RemoteThing","metadata":{"annotations":{},"name":"my-test-thing"},"spec":{"username":"Colonel Mustard"}}`,
+			expectedState: `{"apiVersion":"remote.example.corp/v1alpha1","kind":"RemoteThing","metadata":{"name":"my-test-thing"},"spec":{"username":"Colonel Mustard"}}`,
 		},
 
 		/////////////////////////////////////////////////////////////////////////////////
@@ -352,17 +360,19 @@ func TestSyncerProcessingSingleResourceWithoutStatus(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "testcluster-my-test-thing",
 					Labels: map[string]string{
-						agentNameLabel:             "textor-the-doctor",
-						remoteObjectClusterLabel:   "testcluster",
-						remoteObjectNamespaceLabel: "",
-						remoteObjectNameLabel:      "my-test-thing",
+						agentNameLabel:            "textor-the-doctor",
+						remoteObjectClusterLabel:  "testcluster",
+						remoteObjectNameHashLabel: "c346c8ceb5d104cc783d09b95e8ea7032c190948",
+					},
+					Annotations: map[string]string{
+						remoteObjectNameAnnotation: "my-test-thing",
 					},
 				},
 				Spec: dummyv1alpha1.ThingSpec{
 					Username: "Colonel Mustard",
 				},
 			}),
-			existingState: `{"apiVersion":"remote.example.corp/v1alpha1","kind":"RemoteThing","metadata":{"annotations":{},"name":"my-test-thing"},"spec":{"username":"Colonel Mustard"}}`,
+			existingState: `{"apiVersion":"remote.example.corp/v1alpha1","kind":"RemoteThing","metadata":{"name":"my-test-thing"},"spec":{"username":"Colonel Mustard"}}`,
 
 			expectedRemoteObject: newUnstructured(&dummyv1alpha1.Thing{
 				ObjectMeta: metav1.ObjectMeta{
@@ -379,17 +389,19 @@ func TestSyncerProcessingSingleResourceWithoutStatus(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "testcluster-my-test-thing",
 					Labels: map[string]string{
-						agentNameLabel:             "textor-the-doctor",
-						remoteObjectClusterLabel:   "testcluster",
-						remoteObjectNamespaceLabel: "",
-						remoteObjectNameLabel:      "my-test-thing",
+						agentNameLabel:            "textor-the-doctor",
+						remoteObjectClusterLabel:  "testcluster",
+						remoteObjectNameHashLabel: "c346c8ceb5d104cc783d09b95e8ea7032c190948",
+					},
+					Annotations: map[string]string{
+						remoteObjectNameAnnotation: "my-test-thing",
 					},
 				},
 				Spec: dummyv1alpha1.ThingSpec{
 					Username: "Miss Scarlet",
 				},
 			}),
-			expectedState: `{"apiVersion":"remote.example.corp/v1alpha1","kind":"RemoteThing","metadata":{"annotations":{},"name":"my-test-thing"},"spec":{"username":"Miss Scarlet"}}`,
+			expectedState: `{"apiVersion":"remote.example.corp/v1alpha1","kind":"RemoteThing","metadata":{"name":"my-test-thing"},"spec":{"username":"Miss Scarlet"}}`,
 		},
 
 		/////////////////////////////////////////////////////////////////////////////////
@@ -416,10 +428,12 @@ func TestSyncerProcessingSingleResourceWithoutStatus(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "testcluster-my-test-thing",
 					Labels: map[string]string{
-						agentNameLabel:             "textor-the-doctor",
-						remoteObjectClusterLabel:   "testcluster",
-						remoteObjectNamespaceLabel: "",
-						remoteObjectNameLabel:      "my-test-thing",
+						agentNameLabel:            "textor-the-doctor",
+						remoteObjectClusterLabel:  "testcluster",
+						remoteObjectNameHashLabel: "c346c8ceb5d104cc783d09b95e8ea7032c190948",
+					},
+					Annotations: map[string]string{
+						remoteObjectNameAnnotation: "my-test-thing",
 					},
 				},
 				Spec: dummyv1alpha1.ThingSpec{
@@ -443,17 +457,19 @@ func TestSyncerProcessingSingleResourceWithoutStatus(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "testcluster-my-test-thing",
 					Labels: map[string]string{
-						agentNameLabel:             "textor-the-doctor",
-						remoteObjectClusterLabel:   "testcluster",
-						remoteObjectNamespaceLabel: "",
-						remoteObjectNameLabel:      "my-test-thing",
+						agentNameLabel:            "textor-the-doctor",
+						remoteObjectClusterLabel:  "testcluster",
+						remoteObjectNameHashLabel: "c346c8ceb5d104cc783d09b95e8ea7032c190948",
+					},
+					Annotations: map[string]string{
+						remoteObjectNameAnnotation: "my-test-thing",
 					},
 				},
 				Spec: dummyv1alpha1.ThingSpec{
 					Username: "Colonel Mustard",
 				},
 			}),
-			expectedState: `{"apiVersion":"remote.example.corp/v1alpha1","kind":"RemoteThing","metadata":{"annotations":{},"name":"my-test-thing"},"spec":{"username":"Colonel Mustard"}}`,
+			expectedState: `{"apiVersion":"remote.example.corp/v1alpha1","kind":"RemoteThing","metadata":{"name":"my-test-thing"},"spec":{"username":"Colonel Mustard"}}`,
 		},
 
 		/////////////////////////////////////////////////////////////////////////////////
@@ -489,14 +505,14 @@ func TestSyncerProcessingSingleResourceWithoutStatus(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "testcluster-my-test-thing",
 					Annotations: map[string]string{
-						"existing-annotation": "annotation-value",
+						remoteObjectNameAnnotation: "my-test-thing",
+						"existing-annotation":      "annotation-value",
 					},
 					Labels: map[string]string{
-						agentNameLabel:             "textor-the-doctor",
-						remoteObjectClusterLabel:   "testcluster",
-						remoteObjectNamespaceLabel: "",
-						remoteObjectNameLabel:      "my-test-thing",
-						"existing-label":           "label-value",
+						agentNameLabel:            "textor-the-doctor",
+						remoteObjectClusterLabel:  "testcluster",
+						remoteObjectNameHashLabel: "c346c8ceb5d104cc783d09b95e8ea7032c190948",
+						"existing-label":          "label-value",
 					},
 				},
 				Spec: dummyv1alpha1.ThingSpec{
@@ -530,16 +546,16 @@ func TestSyncerProcessingSingleResourceWithoutStatus(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "testcluster-my-test-thing",
 					Annotations: map[string]string{
-						"existing-annotation": "new-annotation-value",
-						"new-annotation":      "hei-verden",
+						remoteObjectNameAnnotation: "my-test-thing",
+						"existing-annotation":      "new-annotation-value",
+						"new-annotation":           "hei-verden",
 					},
 					Labels: map[string]string{
-						agentNameLabel:             "textor-the-doctor",
-						remoteObjectClusterLabel:   "testcluster",
-						remoteObjectNamespaceLabel: "",
-						remoteObjectNameLabel:      "my-test-thing",
-						"existing-label":           "new-label-value",
-						"new-label":                "hello-world",
+						agentNameLabel:            "textor-the-doctor",
+						remoteObjectClusterLabel:  "testcluster",
+						remoteObjectNameHashLabel: "c346c8ceb5d104cc783d09b95e8ea7032c190948",
+						"existing-label":          "new-label-value",
+						"new-label":               "hello-world",
 					},
 				},
 				Spec: dummyv1alpha1.ThingSpec{
@@ -548,6 +564,72 @@ func TestSyncerProcessingSingleResourceWithoutStatus(t *testing.T) {
 			}),
 			// last state annotation is "space optimized" and so does not include the ignored labels and annotations
 			expectedState: `{"apiVersion":"remote.example.corp/v1alpha1","kind":"RemoteThing","metadata":{"annotations":{"existing-annotation":"new-annotation-value","new-annotation":"hei-verden"},"labels":{"existing-label":"new-label-value","new-label":"hello-world"},"name":"my-test-thing"},"spec":{"username":"Colonel Mustard"}}`,
+		},
+
+		/////////////////////////////////////////////////////////////////////////////////
+
+		{
+			name:            "missing syncagent-related annotations should be patched on the destination object",
+			remoteAPIGroup:  "remote.example.corp",
+			localCRD:        loadCRD("things"),
+			pubRes:          remoteThingPR,
+			performRequeues: true,
+
+			remoteObject: newUnstructured(&dummyv1alpha1.Thing{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "my-test-thing",
+					Finalizers: []string{
+						deletionFinalizer,
+					},
+				},
+				Spec: dummyv1alpha1.ThingSpec{
+					Username: "Colonel Mustard",
+				},
+			}, withGroupKind("remote.example.corp", "RemoteThing")),
+			localObject: newUnstructured(&dummyv1alpha1.Thing{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "testcluster-my-test-thing",
+					Labels: map[string]string{
+						agentNameLabel:            "textor-the-doctor",
+						remoteObjectClusterLabel:  "testcluster",
+						remoteObjectNameHashLabel: "c346c8ceb5d104cc783d09b95e8ea7032c190948",
+					},
+				},
+				Spec: dummyv1alpha1.ThingSpec{
+					Username: "Colonel Mustard",
+				},
+			}),
+			existingState: `{"apiVersion":"remote.example.corp/v1alpha1","kind":"RemoteThing","metadata":{"name":"my-test-thing"},"spec":{"username":"Colonel Mustard"}}`,
+
+			expectedRemoteObject: newUnstructured(&dummyv1alpha1.Thing{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "my-test-thing",
+					Finalizers: []string{
+						deletionFinalizer,
+					},
+				},
+				Spec: dummyv1alpha1.ThingSpec{
+					Username: "Colonel Mustard",
+				},
+			}, withGroupKind("remote.example.corp", "RemoteThing")),
+			expectedLocalObject: newUnstructured(&dummyv1alpha1.Thing{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "testcluster-my-test-thing",
+					Annotations: map[string]string{
+						remoteObjectNameAnnotation: "my-test-thing",
+					},
+					Labels: map[string]string{
+						agentNameLabel:            "textor-the-doctor",
+						remoteObjectClusterLabel:  "testcluster",
+						remoteObjectNameHashLabel: "c346c8ceb5d104cc783d09b95e8ea7032c190948",
+					},
+				},
+				Spec: dummyv1alpha1.ThingSpec{
+					Username: "Colonel Mustard",
+				},
+			}),
+			// last state annotation is "space optimized" and so does not include the ignored labels and annotations
+			expectedState: `{"apiVersion":"remote.example.corp/v1alpha1","kind":"RemoteThing","metadata":{"name":"my-test-thing"},"spec":{"username":"Colonel Mustard"}}`,
 		},
 
 		/////////////////////////////////////////////////////////////////////////////////
@@ -574,10 +656,12 @@ func TestSyncerProcessingSingleResourceWithoutStatus(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "testcluster-my-test-thing",
 					Labels: map[string]string{
-						agentNameLabel:             "textor-the-doctor",
-						remoteObjectClusterLabel:   "testcluster",
-						remoteObjectNamespaceLabel: "",
-						remoteObjectNameLabel:      "my-test-thing",
+						agentNameLabel:            "textor-the-doctor",
+						remoteObjectClusterLabel:  "testcluster",
+						remoteObjectNameHashLabel: "c346c8ceb5d104cc783d09b95e8ea7032c190948",
+					},
+					Annotations: map[string]string{
+						remoteObjectNameAnnotation: "my-test-thing",
 					},
 				},
 				Spec: dummyv1alpha1.ThingSpec{
@@ -585,7 +669,7 @@ func TestSyncerProcessingSingleResourceWithoutStatus(t *testing.T) {
 					Address:  "Hotdogstr. 13", // we assume this field was set by a local controller/webhook, unrelated to the Sync Agent
 				},
 			}),
-			existingState: `{"apiVersion":"remote.example.corp/v1alpha1","kind":"RemoteThing","metadata":{"annotations":{},"name":"my-test-thing"},"spec":{"username":"Colonel Mustard"}}`,
+			existingState: `{"apiVersion":"remote.example.corp/v1alpha1","kind":"RemoteThing","metadata":{"name":"my-test-thing"},"spec":{"username":"Colonel Mustard"}}`,
 
 			expectedRemoteObject: newUnstructured(&dummyv1alpha1.Thing{
 				ObjectMeta: metav1.ObjectMeta{
@@ -602,10 +686,12 @@ func TestSyncerProcessingSingleResourceWithoutStatus(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "testcluster-my-test-thing",
 					Labels: map[string]string{
-						agentNameLabel:             "textor-the-doctor",
-						remoteObjectClusterLabel:   "testcluster",
-						remoteObjectNamespaceLabel: "",
-						remoteObjectNameLabel:      "my-test-thing",
+						agentNameLabel:            "textor-the-doctor",
+						remoteObjectClusterLabel:  "testcluster",
+						remoteObjectNameHashLabel: "c346c8ceb5d104cc783d09b95e8ea7032c190948",
+					},
+					Annotations: map[string]string{
+						remoteObjectNameAnnotation: "my-test-thing",
 					},
 				},
 				Spec: dummyv1alpha1.ThingSpec{
@@ -614,7 +700,7 @@ func TestSyncerProcessingSingleResourceWithoutStatus(t *testing.T) {
 					Address: "Hotdogstr. 13",
 				},
 			}),
-			expectedState: `{"apiVersion":"remote.example.corp/v1alpha1","kind":"RemoteThing","metadata":{"annotations":{},"name":"my-test-thing"},"spec":{"username":"Miss Scarlet"}}`,
+			expectedState: `{"apiVersion":"remote.example.corp/v1alpha1","kind":"RemoteThing","metadata":{"name":"my-test-thing"},"spec":{"username":"Miss Scarlet"}}`,
 		},
 
 		/////////////////////////////////////////////////////////////////////////////////
@@ -648,10 +734,12 @@ func TestSyncerProcessingSingleResourceWithoutStatus(t *testing.T) {
 						"prevent-instant-deletion-in-tests",
 					},
 					Labels: map[string]string{
-						agentNameLabel:             "textor-the-doctor",
-						remoteObjectClusterLabel:   "testcluster",
-						remoteObjectNamespaceLabel: "",
-						remoteObjectNameLabel:      "my-test-thing",
+						agentNameLabel:            "textor-the-doctor",
+						remoteObjectClusterLabel:  "testcluster",
+						remoteObjectNameHashLabel: "c346c8ceb5d104cc783d09b95e8ea7032c190948",
+					},
+					Annotations: map[string]string{
+						remoteObjectNameAnnotation: "my-test-thing",
 					},
 				},
 				Spec: dummyv1alpha1.ThingSpec{
@@ -680,10 +768,12 @@ func TestSyncerProcessingSingleResourceWithoutStatus(t *testing.T) {
 					},
 					DeletionTimestamp: &nonEmptyTime,
 					Labels: map[string]string{
-						agentNameLabel:             "textor-the-doctor",
-						remoteObjectClusterLabel:   "testcluster",
-						remoteObjectNamespaceLabel: "",
-						remoteObjectNameLabel:      "my-test-thing",
+						agentNameLabel:            "textor-the-doctor",
+						remoteObjectClusterLabel:  "testcluster",
+						remoteObjectNameHashLabel: "c346c8ceb5d104cc783d09b95e8ea7032c190948",
+					},
+					Annotations: map[string]string{
+						remoteObjectNameAnnotation: "my-test-thing",
 					},
 				},
 				Spec: dummyv1alpha1.ThingSpec{
@@ -762,10 +852,9 @@ func TestSyncerProcessingSingleResourceWithoutStatus(t *testing.T) {
 					},
 					DeletionTimestamp: &nonEmptyTime,
 					Labels: map[string]string{
-						agentNameLabel:             "textor-the-doctor",
-						remoteObjectClusterLabel:   "testcluster",
-						remoteObjectNamespaceLabel: "",
-						remoteObjectNameLabel:      "my-test-thing",
+						agentNameLabel:            "textor-the-doctor",
+						remoteObjectClusterLabel:  "testcluster",
+						remoteObjectNameHashLabel: "c346c8ceb5d104cc783d09b95e8ea7032c190948",
 					},
 				},
 				Spec: dummyv1alpha1.ThingSpec{
@@ -793,10 +882,9 @@ func TestSyncerProcessingSingleResourceWithoutStatus(t *testing.T) {
 					},
 					DeletionTimestamp: &nonEmptyTime,
 					Labels: map[string]string{
-						agentNameLabel:             "textor-the-doctor",
-						remoteObjectClusterLabel:   "testcluster",
-						remoteObjectNamespaceLabel: "",
-						remoteObjectNameLabel:      "my-test-thing",
+						agentNameLabel:            "textor-the-doctor",
+						remoteObjectClusterLabel:  "testcluster",
+						remoteObjectNameHashLabel: "c346c8ceb5d104cc783d09b95e8ea7032c190948",
 					},
 				},
 				Spec: dummyv1alpha1.ThingSpec{
@@ -987,10 +1075,12 @@ func TestSyncerProcessingSingleResourceWithStatus(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "testcluster-my-test-thing",
 					Labels: map[string]string{
-						agentNameLabel:             "textor-the-doctor",
-						remoteObjectClusterLabel:   "testcluster",
-						remoteObjectNamespaceLabel: "",
-						remoteObjectNameLabel:      "my-test-thing",
+						agentNameLabel:            "textor-the-doctor",
+						remoteObjectClusterLabel:  "testcluster",
+						remoteObjectNameHashLabel: "c346c8ceb5d104cc783d09b95e8ea7032c190948",
+					},
+					Annotations: map[string]string{
+						remoteObjectNameAnnotation: "my-test-thing",
 					},
 				},
 				Spec: dummyv1alpha1.ThingSpec{
@@ -1020,10 +1110,12 @@ func TestSyncerProcessingSingleResourceWithStatus(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "testcluster-my-test-thing",
 					Labels: map[string]string{
-						agentNameLabel:             "textor-the-doctor",
-						remoteObjectClusterLabel:   "testcluster",
-						remoteObjectNamespaceLabel: "",
-						remoteObjectNameLabel:      "my-test-thing",
+						agentNameLabel:            "textor-the-doctor",
+						remoteObjectClusterLabel:  "testcluster",
+						remoteObjectNameHashLabel: "c346c8ceb5d104cc783d09b95e8ea7032c190948",
+					},
+					Annotations: map[string]string{
+						remoteObjectNameAnnotation: "my-test-thing",
 					},
 				},
 				Spec: dummyv1alpha1.ThingSpec{
@@ -1033,7 +1125,7 @@ func TestSyncerProcessingSingleResourceWithStatus(t *testing.T) {
 					CurrentVersion: "v1",
 				},
 			}),
-			expectedState: `{"apiVersion":"remote.example.corp/v1alpha1","kind":"RemoteThing","metadata":{"annotations":{},"name":"my-test-thing"},"spec":{"username":"Colonel Mustard"}}`,
+			expectedState: `{"apiVersion":"remote.example.corp/v1alpha1","kind":"RemoteThing","metadata":{"name":"my-test-thing"},"spec":{"username":"Colonel Mustard"}}`,
 		},
 
 		/////////////////////////////////////////////////////////////////////////////////
@@ -1060,10 +1152,12 @@ func TestSyncerProcessingSingleResourceWithStatus(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "testcluster-my-test-thing",
 					Labels: map[string]string{
-						agentNameLabel:             "textor-the-doctor",
-						remoteObjectClusterLabel:   "testcluster",
-						remoteObjectNamespaceLabel: "",
-						remoteObjectNameLabel:      "my-test-thing",
+						agentNameLabel:            "textor-the-doctor",
+						remoteObjectClusterLabel:  "testcluster",
+						remoteObjectNameHashLabel: "c346c8ceb5d104cc783d09b95e8ea7032c190948",
+					},
+					Annotations: map[string]string{
+						remoteObjectNameAnnotation: "my-test-thing",
 					},
 				},
 				Spec: dummyv1alpha1.ThingSpec{
@@ -1093,10 +1187,12 @@ func TestSyncerProcessingSingleResourceWithStatus(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "testcluster-my-test-thing",
 					Labels: map[string]string{
-						agentNameLabel:             "textor-the-doctor",
-						remoteObjectClusterLabel:   "testcluster",
-						remoteObjectNamespaceLabel: "",
-						remoteObjectNameLabel:      "my-test-thing",
+						agentNameLabel:            "textor-the-doctor",
+						remoteObjectClusterLabel:  "testcluster",
+						remoteObjectNameHashLabel: "c346c8ceb5d104cc783d09b95e8ea7032c190948",
+					},
+					Annotations: map[string]string{
+						remoteObjectNameAnnotation: "my-test-thing",
 					},
 				},
 				Spec: dummyv1alpha1.ThingSpec{
@@ -1106,7 +1202,7 @@ func TestSyncerProcessingSingleResourceWithStatus(t *testing.T) {
 					CurrentVersion: "v1",
 				},
 			}),
-			expectedState: `{"apiVersion":"remote.example.corp/v1alpha1","kind":"RemoteThing","metadata":{"annotations":{},"name":"my-test-thing"},"spec":{"username":"Colonel Mustard"}}`,
+			expectedState: `{"apiVersion":"remote.example.corp/v1alpha1","kind":"RemoteThing","metadata":{"name":"my-test-thing"},"spec":{"username":"Colonel Mustard"}}`,
 		},
 	}
 

--- a/internal/sync/types.go
+++ b/internal/sync/types.go
@@ -27,9 +27,12 @@ const (
 	// origin remote objects. Note that the cluster *path* label is optional and
 	// has to be enabled per PublishedResource.
 
-	remoteObjectClusterLabel   = "syncagent.kcp.io/remote-object-cluster"
-	remoteObjectNamespaceLabel = "syncagent.kcp.io/remote-object-namespace"
-	remoteObjectNameLabel      = "syncagent.kcp.io/remote-object-name"
+	remoteObjectClusterLabel       = "syncagent.kcp.io/remote-object-cluster"
+	remoteObjectNamespaceHashLabel = "syncagent.kcp.io/remote-object-namespace-hash"
+	remoteObjectNameHashLabel      = "syncagent.kcp.io/remote-object-name-hash"
+
+	remoteObjectNamespaceAnnotation = "syncagent.kcp.io/remote-object-namespace"
+	remoteObjectNameAnnotation      = "syncagent.kcp.io/remote-object-name"
 
 	remoteObjectWorkspacePathAnnotation = "syncagent.kcp.io/remote-object-workspace-path"
 

--- a/test/e2e/sync/primary_test.go
+++ b/test/e2e/sync/primary_test.go
@@ -32,6 +32,7 @@ import (
 	syncagentv1alpha1 "github.com/kcp-dev/api-syncagent/sdk/apis/syncagent/v1alpha1"
 	"github.com/kcp-dev/api-syncagent/test/utils"
 
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -447,5 +448,98 @@ spec:
 	})
 	if err == nil {
 		t.Fatal("Expected no ignored object to be found on the service cluster, but did.")
+	}
+}
+
+func TestSyncingOverlyLongNames(t *testing.T) {
+	const (
+		apiExportName = "kcp.example.com"
+		orgWorkspace  = "sync-long-names"
+	)
+
+	ctx := context.Background()
+	ctrlruntime.SetLogger(logr.Discard())
+
+	// setup a test environment in kcp
+	orgKubconfig := utils.CreateOrganization(t, ctx, orgWorkspace, apiExportName)
+
+	// start a service cluster
+	envtestKubeconfig, envtestClient, _ := utils.RunEnvtest(t, []string{
+		"test/crds/crontab.yaml",
+	})
+
+	// publish Crontabs and Backups
+	t.Logf("Publishing CRDs…")
+	prCrontabs := &syncagentv1alpha1.PublishedResource{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "publish-crontabs",
+		},
+		Spec: syncagentv1alpha1.PublishedResourceSpec{
+			Resource: syncagentv1alpha1.SourceResourceDescriptor{
+				APIGroup: "example.com",
+				Version:  "v1",
+				Kind:     "CronTab",
+			},
+			// These rules make finding the local object easier, but should not be used in production.
+			Naming: &syncagentv1alpha1.ResourceNaming{
+				Name:      "$remoteName",
+				Namespace: "synced-$remoteNamespace",
+			},
+		},
+	}
+
+	if err := envtestClient.Create(ctx, prCrontabs); err != nil {
+		t.Fatalf("Failed to create PublishedResource: %v", err)
+	}
+
+	// start the agent in the background to update the APIExport with the CronTabs API
+	utils.RunAgent(ctx, t, "bob", orgKubconfig, envtestKubeconfig, apiExportName)
+
+	// wait until the API is available
+	teamCtx := kontext.WithCluster(ctx, logicalcluster.Name(fmt.Sprintf("root:%s:team-1", orgWorkspace)))
+	kcpClient := utils.GetKcpAdminClusterClient(t)
+	utils.WaitForBoundAPI(t, teamCtx, kcpClient, schema.GroupVersionResource{
+		Group:    apiExportName,
+		Version:  "v1",
+		Resource: "crontabs",
+	})
+
+	// create a namespace and CronTab with extremely long names
+	namespace := &corev1.Namespace{}
+	namespace.Name = strings.Repeat("yadda", 3) // 250 chars in total
+
+	if err := kcpClient.Create(teamCtx, namespace); err != nil {
+		t.Fatalf("Failed to create namespace in kcp: %v", err)
+	}
+
+	t.Log("Creating CronTab in kcp…")
+	ignoredCrontab := yamlToUnstructured(t, `
+apiVersion: kcp.example.com/v1
+kind: CronTab
+metadata:
+  name: TBD
+spec:
+  image: ubuntu:latest
+`)
+	ignoredCrontab.SetNamespace(namespace.Name)
+	ignoredCrontab.SetName(strings.Repeat("yotta", 50))
+
+	if err := kcpClient.Create(teamCtx, ignoredCrontab); err != nil {
+		t.Fatalf("Failed to create CronTab in kcp: %v", err)
+	}
+
+	// wait for the agent to sync the object down into the service cluster
+
+	t.Logf("Wait for CronTab to be synced…")
+	copy := &unstructured.Unstructured{}
+	copy.SetAPIVersion("example.com/v1")
+	copy.SetKind("CronTab")
+
+	err := wait.PollUntilContextTimeout(ctx, 500*time.Millisecond, 30*time.Second, false, func(ctx context.Context) (done bool, err error) {
+		copyKey := types.NamespacedName{Namespace: "synced-default", Name: "included"}
+		return envtestClient.Get(ctx, copyKey, copy) == nil, nil
+	})
+	if err != nil {
+		t.Fatalf("Failed to wait for object to be synced down: %v", err)
 	}
 }

--- a/test/e2e/sync/primary_test.go
+++ b/test/e2e/sync/primary_test.go
@@ -518,6 +518,7 @@ apiVersion: kcp.example.com/v1
 kind: CronTab
 metadata:
   name: TBD
+  namespace: TBD
 spec:
   image: ubuntu:latest
 `)
@@ -536,7 +537,7 @@ spec:
 	copy.SetKind("CronTab")
 
 	err := wait.PollUntilContextTimeout(ctx, 500*time.Millisecond, 30*time.Second, false, func(ctx context.Context) (done bool, err error) {
-		copyKey := types.NamespacedName{Namespace: "synced-default", Name: "included"}
+		copyKey := types.NamespacedName{Namespace: fmt.Sprintf("synced-%s", namespace.Name), Name: ignoredCrontab.GetName()}
 		return envtestClient.Get(ctx, copyKey, copy) == nil, nil
 	})
 	if err != nil {


### PR DESCRIPTION
## Summary
Objects in Kubernetes can have names up to 253 characters in length. However label values must not be longer than 63 characters. Since the agent uses the remote (kcp) name/namespace as labels, the syncing failed when objects with names longer than 63 characters were in kcp.

This PR fixes that by hashing the namespace/name and storing the original names, for reference, as annotations instead. The same issue affected the secret store, because keys in a secret's data must also not be overly long, so the agent now uses hashes for these as well.

Existing synced objects will not be found under this new implementation, but the agent will already automatically "adopt" existing objects and re-label/annotate them as needed. The data in the store secrets will also be recreated, so effectively every object is fully re-created on the service cluster side, potentially undoing changes from operators. Good thing this is alpha software :grin:

## Related issue(s)
Fixes #34

## Release Notes
```release-note
Fix syncing errors when object names/namespaces in kcp exceeded 63 characters in length.
```
