### PR TITLE
🐛 update goreleaser config to version 2

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+version: 2
 builds:
   - id: "api-syncagent"
     main: ./cmd/api-syncagent
@@ -29,7 +30,7 @@ builds:
 
 archives:
   - id: api-syncagent
-    builds:
+    ids:
       - api-syncagent
 
 release:


### PR DESCRIPTION
## Summary
This gets rid of the deprecation warnings.

## Release Notes
```release-note
NONE
```
