### PR TITLE
:book: docs: add missing RBAC bindings / rules

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -151,6 +151,8 @@ the RBAC rules that grant the Agent access.
 
 The Sync Agent needs to
 
+* access the workspace of its `APIExport`,
+* get the `LogicalCluster`,
 * manage its `APIExport`,
 * manage `APIResourceSchemas` and
 * access the virtual workspace for its `APIExport`.
@@ -163,6 +165,15 @@ kind: ClusterRole
 metadata:
   name: api-syncagent-mango
 rules:
+  # get the LogicalCluster
+  - apiGroups:
+      - core.kcp.io
+    resources:
+      - logicalclusters
+    resourceNames:
+      - cluster
+    verbs:
+      - get
   # manage its APIExport
   - apiGroups:
       - apis.kcp.io
@@ -200,11 +211,24 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: api-syncagent-columbo:mango-system
+  name: api-syncagent-mango:system
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: api-syncagent-mango
+subjects:
+  - kind: User
+    name: api-syncagent-mango
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: api-syncagent-mango:access
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:kcp:workspace:access
 subjects:
   - kind: User
     name: api-syncagent-mango


### PR DESCRIPTION
## Summary

The api-syncagent [gets the `LogicalCluster`](https://github.com/kcp-dev/api-syncagent/blob/v0.2.0/cmd/api-syncagent/main.go#L227) to resolve the logical cluster name and path. However, this is not reflected in the `ClusterRole` described in the "Getting Started" guide. Additionally, if we create the `APIExport` for the api-syncagent in a workspace other than root, we also need to explicitly grant the user access to it.

This PR adds the missing RBAC rule to the existing `ClusterRole` and an additional `ClusterRoleBinding` to grant the access to the workspace.

## Release Notes

```release-note
NONE
```