### PR TITLE
docs: add workflow for publishing docs to gh-pages

### DIFF
--- a/.github/workflows/gh-pages.yaml
+++ b/.github/workflows/gh-pages.yaml
@@ -1,0 +1,42 @@
+name: Build and publish mkdocs
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+
+jobs:
+
+  deploy:
+
+    runs-on: ubuntu-latest
+
+    steps:
+
+      - uses: actions/checkout@v4
+
+      - name: Configure Git Credentials
+        run: |
+          git config user.name kcp-ci-bot
+          git config user.email no-reply@kcp.io
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+          cache: 'pip'
+
+      - run: echo "cache_id=$(date --utc '+%V')" >> $GITHUB_ENV
+
+      - uses: actions/cache@v4
+        with:
+          key: mkdocs-material-${{ env.cache_id }}
+          path: .cache 
+          restore-keys: |
+            mkdocs-material-
+
+      - run: pip install mkdocs-material mkdocs-macros-plugin mkdocs-awesome-pages-plugin mkdocs-static-i18n
+
+      - run: cd docs && mkdocs gh-deploy --force

--- a/docs/content/publish-resources.md
+++ b/docs/content/publish-resources.md
@@ -396,8 +396,10 @@ spec:
               replacement: "bar-\\1"
 
             # or
+{% raw %}
             template:
               template: "{{ .Name }}-foo"
+{% endraw %}
 
         # Like with references, the namespace can (or must) be configured explicitly.
         # You do not need to also use label selectors here, you can mix and match
@@ -413,7 +415,7 @@ spec:
 #### Templates
 
 The third option to configure how to find/create related objects are templates. These are simple
-Go template strings (like `{{ .Variable }}`) that allow to easily configure static values with a
+Go template strings (like `{% raw %}{{ .Variable }}{% endraw %}`) that allow to easily configure static values with a
 sprinkling of dynamic values.
 
 This feature has not been fully implemented yet.


### PR DESCRIPTION


## Summary
Adding github workflow to publish docs markdown files as gh-pages. Similar to what is done in https://github.com/kcp-dev/contrib

## What Type of PR Is This?
/kind documentation

## Related Issue(s)
https://github.com/kcp-dev/api-syncagent/issues/26

Fixes #
N/A

## Release Notes

```release-note
NONE
```
