### PR TITLE
Update prow jobs to infra/build:1.23.7-2 image for ARM64 support

### DIFF
--- a/.prow.yaml
+++ b/.prow.yaml
@@ -21,7 +21,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: ghcr.io/kcp-dev/infra/build:1.23.5-1
+        - image: ghcr.io/kcp-dev/infra/build:1.23.7-2
           command:
             - hack/ci/verify.sh
           resources:
@@ -37,7 +37,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: ghcr.io/kcp-dev/infra/build:1.23.5-1
+        - image: ghcr.io/kcp-dev/infra/build:1.23.7-2
           command:
             - make
             - lint
@@ -76,7 +76,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: ghcr.io/kcp-dev/infra/build:1.23.5-1
+        - image: ghcr.io/kcp-dev/infra/build:1.23.7-2
           command:
             - make
             - test
@@ -96,7 +96,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: ghcr.io/kcp-dev/infra/build:1.23.5-1
+        - image: ghcr.io/kcp-dev/infra/build:1.23.7-2
           command:
             - hack/ci/run-e2e-tests.sh
           resources:


### PR DESCRIPTION
## Summary

Same as https://github.com/kcp-dev/kcp/pull/3398.

## What Type of PR Is This?

/kind cleanup

## Related Issue(s)

Fixes #

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
NONE
```
