### PR TITLE
pin Github actions in release workflow, update release pipeline to Go 1.23.7

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,41 +21,42 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # tag=v4.2.2
         with:
           fetch-depth: 0
-    
-      - uses: actions/setup-go@v5
+
+      - uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # tag=v5.4.0
         with:
-          go-version: v1.22.10
-    
+          go-version: v1.23.7
+          cache: true
+
       - name: Delete non-semver tags
         run: 'git tag -d $(git tag -l | grep -v "^v")'
-      
+
       - name: Set LDFLAGS
         run: echo LDFLAGS="$(make ldflags)" >> $GITHUB_ENV
-    
+
       - name: Run GoReleaser on tag
         if: github.event_name != 'pull_request'
-        uses: goreleaser/goreleaser-action@v6
+        uses: goreleaser/goreleaser-action@9c156ee8a17a598857849441385a2041ef570552 # tag=v6.3.0
         with:
           distribution: goreleaser
-          version: latest
+          version: '~> v2'
           args: release --timeout 60m
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    
+
       - name: Run GoReleaser on pull request
         if: github.event_name == 'pull_request'
-        uses: goreleaser/goreleaser-action@v6
+        uses: goreleaser/goreleaser-action@9c156ee8a17a598857849441385a2041ef570552 # tag=v6.3.0
         with:
           distribution: goreleaser
-          version: latest
+          version: '~> v2'
           args: release --timeout 60m --snapshot
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    
-      - uses: actions/upload-artifact@v4
+
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # tag=v4.6.2
         if: github.event_name == 'pull_request'
         with:
           name: binaries


### PR DESCRIPTION
## Summary
The docs workflow already does the same :)

## What Type of PR Is This?
/kind cleanup

## Release Notes
```release-note
Update to Go 1.23.7.
```
