### PR TITLE
update golangci-lint to 2.1.6

### DIFF
--- a/.gimps.yaml
+++ b/.gimps.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# This is the configuration for https://github.com/xrstf/gimps.
+# This is the configuration for https://codeberg.org/xrstf/gimps.
 
 importOrder: [std, external, project, kcp, kubernetes]
 sets:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -12,11 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+version: "2"
 run:
   modules-download-mode: readonly
-  timeout: 20m
-
 linters:
+  default: none
   enable:
     - asciicheck
     - bidichk
@@ -31,8 +31,6 @@ linters:
     - gocritic
     - gocyclo
     - godot
-    - gofmt
-    - gosimple
     - govet
     - importas
     - ineffassign
@@ -48,47 +46,65 @@ linters:
     - usetesting
     - wastedassign
     - whitespace
-  disable-all: true
-
+  settings:
+    depguard:
+      rules:
+        main:
+          deny:
+            - pkg: io/ioutil
+              desc: https://go.dev/doc/go1.16#ioutil
+            - pkg: github.com/ghodss/yaml
+              desc: use sigs.k8s.io/yaml instead
+    importas:
+      alias:
+        # Sync Agent APIs
+        - pkg: github.com/kcp-dev/api-syncagent/sdk/apis/(\w+)/(v[\w\d]+)
+          alias: $1$2
+        # Kubernetes
+        - pkg: k8s.io/api/(\w+)/(v[\w\d]+)
+          alias: $1$2
+        - pkg: k8s.io/apimachinery/pkg/apis/meta/v1
+          alias: metav1
+        - pkg: k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1
+          alias: apiextensionsv1
+        - pkg: k8s.io/apimachinery/pkg/api/errors
+          alias: apierrors
+        - pkg: k8s.io/apimachinery/pkg/util/errors
+          alias: utilerrors
+        # Controller Runtime
+        - pkg: sigs.k8s.io/controller-runtime/pkg/client
+          alias: ctrlruntimeclient
+      no-unaliased: true
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    rules:
+      # gocritic
+      - path: (.+)\.go$
+        text: singleCaseSwitch # in most cases this is the beginning of a lookup table and should be kept an obvious table
+      # staticcheck
+      - path: (.+)\.go$
+        text: QF1008 # embedded field names in selectors often make the code more readable, though more verbose
+    paths:
+      - zz_generated.*.go
+      - third_party$
+      - builtin$
+      - examples$
 issues:
   # defaults to 3, which often needlessly hides issues and forces
   # to re-run the linter across the entire repo many times
   max-same-issues: 0
-
-  exclude-files:
-    - zz_generated.*.go
-
-  # NOTE: Do not use commas in the exclude patterns, or else the regex will be
-  # split and you will be sad: https://github.com/golangci/golangci-lint/issues/665
-  exclude:
-    # gocritic
-    - singleCaseSwitch # in most cases this is the beginning of a lookup table and should be kept an obvious table
-
-linters-settings:
-  depguard:
-    rules:
-      main:
-        deny:
-          - { pkg: io/ioutil, desc: https://go.dev/doc/go1.16#ioutil }
-          - { pkg: github.com/ghodss/yaml, desc: use sigs.k8s.io/yaml instead }
-
-  importas:
-    no-unaliased: true
-    alias:
-      # Sync Agent APIs
-      - pkg: github.com/kcp-dev/api-syncagent/sdk/apis/(\w+)/(v[\w\d]+)
-        alias: $1$2
-      # Kubernetes
-      - pkg: k8s.io/api/(\w+)/(v[\w\d]+)
-        alias: $1$2
-      - pkg: k8s.io/apimachinery/pkg/apis/meta/v1
-        alias: metav1
-      - pkg: k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1
-        alias: apiextensionsv1
-      - pkg: k8s.io/apimachinery/pkg/api/errors
-        alias: apierrors
-      - pkg: k8s.io/apimachinery/pkg/util/errors
-        alias: utilerrors
-      # Controller Runtime
-      - pkg: sigs.k8s.io/controller-runtime/pkg/client
-        alias: ctrlruntimeclient
+formatters:
+  enable:
+    - gofmt
+  exclusions:
+    generated: lax
+    paths:
+      - zz_generated.*.go
+      - third_party$
+      - builtin$
+      - examples$

--- a/Makefile
+++ b/Makefile
@@ -53,12 +53,12 @@ $(GOLANGCI_LINT):
 	  ${GOLANGCI_LINT_VERSION}
 
 GIMPS = _tools/gimps
-GIMPS_VERSION = 0.6.0
+GIMPS_VERSION = 0.6.3
 
 .PHONY: $(GIMPS)
 $(GIMPS):
 	@hack/download-tool.sh \
-	  https://github.com/xrstf/gimps/releases/download/v${GIMPS_VERSION}/gimps_${GIMPS_VERSION}_${GOOS}_${GOARCH}.tar.gz \
+	  https://codeberg.org/xrstf/gimps/releases/download/v${GIMPS_VERSION}/gimps_${GIMPS_VERSION}_${GOOS}_${GOARCH}.tar.gz \
 	  gimps \
 	  ${GIMPS_VERSION}
 

--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ $(BUILD_DEST)/%: cmd/%
 	go build $(GOTOOLFLAGS) -o $@ ./cmd/$*
 
 GOLANGCI_LINT = _tools/golangci-lint
-GOLANGCI_LINT_VERSION = 1.64.2
+GOLANGCI_LINT_VERSION = 2.1.6
 
 .PHONY: $(GOLANGCI_LINT)
 $(GOLANGCI_LINT):
@@ -64,6 +64,7 @@ $(GIMPS):
 
 # wwhrd is installed as a Go module rather than from the provided
 # binaries because there is no arm64 binary available from the author.
+# See https://github.com/frapposelli/wwhrd/issues/141
 
 WWHRD = _tools/wwhrd
 WWHRD_VERSION = 06b99400ca6db678386ba5dc39bbbdcdadb664ff
@@ -135,6 +136,7 @@ clean:
 lint: $(GOLANGCI_LINT)
 	$(GOLANGCI_LINT) run \
 		--verbose \
+		--timeout 20m \
 		--print-resources-usage \
 		./...
 
@@ -146,7 +148,6 @@ imports: $(GIMPS)
 verify:
 	./hack/verify-boilerplate.sh
 	./hack/verify-licenses.sh
-
 
 ### docs
 

--- a/internal/discovery/client.go
+++ b/internal/discovery/client.go
@@ -84,7 +84,7 @@ func (c *Client) RetrieveCRD(ctx context.Context, gk schema.GroupKind) (*apiexte
 		// parse and check GroupVersion of the entire list.
 		gv, err := schema.ParseGroupVersion(resList.GroupVersion)
 		if err != nil {
-			return nil, fmt.Errorf("Kubernetes reported invalid API group version %q: %w", resList.GroupVersion, err)
+			return nil, fmt.Errorf("invalid API group version %q reported by Kubernetes: %w", resList.GroupVersion, err)
 		}
 
 		if gv.Group != gk.Group {
@@ -315,7 +315,7 @@ func (c *Client) getPreferredVersion(resource *metav1.APIResource) (string, erro
 		// parse and check GroupVersion of the entire list.
 		gv, err := schema.ParseGroupVersion(resList.GroupVersion)
 		if err != nil {
-			return "", fmt.Errorf("Kubernetes reported invalid API group version %q: %w", resList.GroupVersion, err)
+			return "", fmt.Errorf("invalid API group version %q reported by Kubernetes: %w", resList.GroupVersion, err)
 		}
 
 		if gv.Group != resource.Group {


### PR DESCRIPTION
## Summary
One of the less painful golangci-lint 2 migrations I have seen and done in the last few weeks.

## What Type of PR Is This?
/kind chore

## Release Notes
```release-note
NONE
```
