### PR TITLE
fix missing templating in namespace selectors

### DIFF
--- a/internal/sync/syncer_related.go
+++ b/internal/sync/syncer_related.go
@@ -278,7 +278,12 @@ func resolveRelatedResourceOriginNamespaces(relatedOrigin, relatedDest syncSide,
 	case spec.Selector != nil:
 		namespaces := &corev1.NamespaceList{}
 
-		selector, err := metav1.LabelSelectorAsSelector(&spec.Selector.LabelSelector)
+		labelSelector, err := templateLabelSelector(relatedOrigin, relatedDest, origin, &spec.Selector.LabelSelector)
+		if err != nil {
+			return nil, fmt.Errorf("failed to apply templates to label selector: %w", err)
+		}
+
+		selector, err := metav1.LabelSelectorAsSelector(labelSelector)
 		if err != nil {
 			return nil, fmt.Errorf("invalid selector configured: %w", err)
 		}


### PR DESCRIPTION
## Summary
Just like for the selector for the object by name, the selector for the namespaces should also be templated.

## What Type of PR Is This?
/kind bug

## Release Notes
```release-note
Fix missing templating in namespace selectors
```
