### PR TITLE
fix example in label selector renaming

### DIFF
--- a/docs/content/publish-resources/index.md
+++ b/docs/content/publish-resources/index.md
@@ -519,7 +519,7 @@ spec:
 
             # or
             template:
-              template: "{{ .Name }}-foo"
+              template: "{{ .Value }}-foo"
 
         # Like with references, the namespace can (or must) be configured explicitly.
         # You do not need to also use label selectors here, you can mix and match


### PR DESCRIPTION
## Summary
One of the examples was still using the old style of templating logic.

## What Type of PR Is This?
/kind documentation

## Release Notes
```release-note
NONE
```
