### PR TITLE
Fix release branch naming scheme and badge links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # kcp API Sync Agent
 
 [![Go Report Card](https://goreportcard.com/badge/github.com/kcp-dev/api-syncagent)](https://goreportcard.com/report/github.com/kcp-dev/api-syncagent)
-[![GitHub](https://img.shields.io/github/license/kcp-dev/api-syncagent)](https://img.shields.io/github/license/kcp-dev/api-syncagent)
-[![GitHub release (latest SemVer)](https://img.shields.io/github/v/release/kcp-dev/api-syncagent?sort=semver)](https://img.shields.io/github/v/release/kcp-dev/api-syncagent?sort=semver)
+[![GitHub](https://img.shields.io/github/license/kcp-dev/api-syncagent)](https://github.com/kcp-dev/api-syncagent/blob/main/LICENSE)
+[![GitHub release (latest SemVer)](https://img.shields.io/github/v/release/kcp-dev/api-syncagent?sort=semver)](https://github.com/kcp-dev/api-syncagent/releases/latest)
 [![FOSSA Status](https://app.fossa.com/api/projects/git%2Bgithub.com%2Fkcp-dev%2Fapi-syncagent.svg?type=shield)](https://app.fossa.com/projects/git%2Bgithub.com%2Fkcp-dev%2Fapi-syncagent?ref=badge_shield)
 
 The kcp API Sync Agent is a Kubernetes controller capable of synchronizing objects from many kcp

--- a/docs/content/contributing/releasing.md
+++ b/docs/content/contributing/releasing.md
@@ -16,8 +16,8 @@ tag represents where the corresponding `release/v0.X` branch branches off.
 1. Tag the main module: `git tag -m "version 0.X" v0.X.0`
 1. Tag the SDK module: `git tag -m "SDK version 0.X" sdk/v0.X.0`
 1. Push the tags: `git push upstream v0.X.0 sdk/v0.X.0`
-1. Create the release branch: `git checkout -B release/v0.X`
-1. Push the release branch: `git push -u upstream release/v0.X`
+1. Create the release branch: `git checkout -B release-v0.X`
+1. Push the release branch: `git push -u upstream release-v0.X`
 
 ## Patch Releases
 


### PR DESCRIPTION
<!--

Thanks for creating a pull request!
If this is your first time, please make sure to review CONTRIBUTING.MD.

-->

## Summary

Noticed this in https://github.com/kcp-dev/kcp-operator/pull/60: https://github.com/kcp-dev/infra/blob/48b16067ca1bead2922eb87e3f9d8207b641a737/prow/jobs/kcp-dev/api-syncagent/api-syncagent-postsubmits.yaml#L11

Bumping the badges to link to the correct destination as well.

## What Type of PR Is This?

/kind documentation

## Related Issue(s)

Fixes #

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
NONE
```
