### PR TITLE
Undeprecate references

### DIFF
--- a/deploy/crd/kcp.io/syncagent.kcp.io_publishedresources.yaml
+++ b/deploy/crd/kcp.io/syncagent.kcp.io_publishedresources.yaml
@@ -239,10 +239,17 @@ spec:
                     name:
                       description: |-
                         The name field allows to control the name the local objects created by the Sync Agent.
-                        If left empty, "$remoteNamespaceHash-$remoteNameHash" is assumed. This guarantees unique
-                        names as long as the cluster name ($remoteClusterName) is used for the local namespace
+                        If left empty, the default value is:
+
+                          "{{ .Object.metadata.namespace | sha3short }}-{{ .Object.metadata.name | sha3short }}"
+
+                        This guarantees unique names as long as the cluster name is used for the local namespace
                         (the default unless configured otherwise).
-                        This is a string with placeholders. The following placeholders can be used:
+
+                        This value is a Go template, see the documentation for the available variables and functions.
+
+                        Alternatively (but deprecated), this value can be a simple string using one of the following
+                        placeholders:
 
                           - $remoteClusterName   -- the kcp workspace's cluster name (e.g. "1084s8ceexsehjm2")
                           - $remoteNamespace     -- the original namespace used by the consumer inside the kcp
@@ -252,12 +259,19 @@ spec:
                           - $remoteName          -- the original name of the object inside the kcp workspace
                                                     (rarely used to construct local namespace names)
                           - $remoteNameHash      -- first 20 hex characters of the SHA-1 hash of $remoteName
+
+                        Authors are advised to use Go templates instead, as the custom variable syntax is deprecated
+                        and will be removed from a future release of the Sync Agent.
                       type: string
                     namespace:
                       description: |-
                         For namespaced resources, the this field allows to control where the local objects will
-                        be created. If left empty, "$remoteClusterName" is assumed.
-                        This is a string with placeholders. The following placeholders can be used:
+                        be created. If left empty, "{{ .ClusterName }}" is assumed.
+
+                        This value is a Go template, see the documentation for the available variables and functions.
+
+                        Alternatively (but deprecated), this value can be a simple string using one of the following
+                        placeholders:
 
                           - $remoteClusterName   -- the kcp workspace's cluster name (e.g. "1084s8ceexsehjm2")
                           - $remoteNamespace     -- the original namespace used by the consumer inside the kcp
@@ -267,6 +281,9 @@ spec:
                           - $remoteName          -- the original name of the object inside the kcp workspace
                                                     (rarely used to construct local namespace names)
                           - $remoteNameHash      -- first 20 hex characters of the SHA-1 hash of $remoteName
+
+                        Authors are advised to use Go templates instead, as the custom variable syntax is deprecated
+                        and will be removed from a future release of the Sync Agent.
                       type: string
                   type: object
                 projection:
@@ -438,8 +455,6 @@ spec:
                                 description: |-
                                   Reference points to a field inside the main object. This reference is
                                   evaluated on both source and destination sides to find the related object.
-
-                                  Deprecated: Use Go templates instead.
                                 properties:
                                   path:
                                     description: |-
@@ -555,8 +570,6 @@ spec:
                             description: |-
                               Reference points to a field inside the main object. This reference is
                               evaluated on both source and destination sides to find the related object.
-
-                              Deprecated: Use Go templates instead.
                             properties:
                               path:
                                 description: |-

--- a/internal/sync/syncer_related.go
+++ b/internal/sync/syncer_related.go
@@ -251,7 +251,7 @@ func resolveRelatedResourceObjects(relatedOrigin, relatedDest syncSide, relRes s
 func resolveRelatedResourceOriginNamespaces(relatedOrigin, relatedDest syncSide, origin syncagentv1alpha1.RelatedResourceOrigin, spec syncagentv1alpha1.RelatedResourceObjectSpec) (map[string]string, error) {
 	switch {
 	case spec.Reference != nil:
-		originNamespace, err := resolveObjectReference(relatedOrigin.object, *spec.Reference) //nolint:staticcheck
+		originNamespace, err := resolveObjectReference(relatedOrigin.object, *spec.Reference)
 		if err != nil {
 			return nil, err
 		}
@@ -260,7 +260,7 @@ func resolveRelatedResourceOriginNamespaces(relatedOrigin, relatedDest syncSide,
 			return nil, nil
 		}
 
-		destNamespace, err := resolveObjectReference(relatedDest.object, *spec.Reference) //nolint:staticcheck
+		destNamespace, err := resolveObjectReference(relatedDest.object, *spec.Reference)
 		if err != nil {
 			return nil, err
 		}
@@ -367,9 +367,8 @@ func resolveRelatedResourceObjectsInNamespaces(relatedOrigin, relatedDest syncSi
 
 func resolveRelatedResourceObjectsInNamespace(relatedOrigin, relatedDest syncSide, relRes syncagentv1alpha1.RelatedResourceSpec, spec syncagentv1alpha1.RelatedResourceObjectSpec, namespace string) (map[string]string, error) {
 	switch {
-	//nolint:staticcheck
 	case spec.Reference != nil:
-		originName, err := resolveObjectReference(relatedOrigin.object, *spec.Reference) //nolint:staticcheck
+		originName, err := resolveObjectReference(relatedOrigin.object, *spec.Reference)
 		if err != nil {
 			return nil, err
 		}
@@ -378,7 +377,7 @@ func resolveRelatedResourceObjectsInNamespace(relatedOrigin, relatedDest syncSid
 			return nil, nil
 		}
 
-		destName, err := resolveObjectReference(relatedDest.object, *spec.Reference) //nolint:staticcheck
+		destName, err := resolveObjectReference(relatedDest.object, *spec.Reference)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/sync/syncer_related.go
+++ b/internal/sync/syncer_related.go
@@ -250,7 +250,6 @@ func resolveRelatedResourceObjects(relatedOrigin, relatedDest syncSide, relRes s
 
 func resolveRelatedResourceOriginNamespaces(relatedOrigin, relatedDest syncSide, origin syncagentv1alpha1.RelatedResourceOrigin, spec syncagentv1alpha1.RelatedResourceObjectSpec) (map[string]string, error) {
 	switch {
-	//nolint:staticcheck // .Reference is deprecated, but we still support it for now.
 	case spec.Reference != nil:
 		originNamespace, err := resolveObjectReference(relatedOrigin.object, *spec.Reference) //nolint:staticcheck
 		if err != nil {

--- a/sdk/apis/syncagent/v1alpha1/published_resource.go
+++ b/sdk/apis/syncagent/v1alpha1/published_resource.go
@@ -102,10 +102,17 @@ type PublishedResourceSpec struct {
 // ResourceNaming describes how the names for local objects should be formed.
 type ResourceNaming struct {
 	// The name field allows to control the name the local objects created by the Sync Agent.
-	// If left empty, "$remoteNamespaceHash-$remoteNameHash" is assumed. This guarantees unique
-	// names as long as the cluster name ($remoteClusterName) is used for the local namespace
+	// If left empty, the default value is:
+	//
+	//   "{{ .Object.metadata.namespace | sha3short }}-{{ .Object.metadata.name | sha3short }}"
+	//
+	// This guarantees unique names as long as the cluster name is used for the local namespace
 	// (the default unless configured otherwise).
-	// This is a string with placeholders. The following placeholders can be used:
+	//
+	// This value is a Go template, see the documentation for the available variables and functions.
+	//
+	// Alternatively (but deprecated), this value can be a simple string using one of the following
+	// placeholders:
 	//
 	//   - $remoteClusterName   -- the kcp workspace's cluster name (e.g. "1084s8ceexsehjm2")
 	//   - $remoteNamespace     -- the original namespace used by the consumer inside the kcp
@@ -116,11 +123,17 @@ type ResourceNaming struct {
 	//                             (rarely used to construct local namespace names)
 	//   - $remoteNameHash      -- first 20 hex characters of the SHA-1 hash of $remoteName
 	//
+	// Authors are advised to use Go templates instead, as the custom variable syntax is deprecated
+	// and will be removed from a future release of the Sync Agent.
 	Name string `json:"name,omitempty"`
 
 	// For namespaced resources, the this field allows to control where the local objects will
-	// be created. If left empty, "$remoteClusterName" is assumed.
-	// This is a string with placeholders. The following placeholders can be used:
+	// be created. If left empty, "{{ .ClusterName }}" is assumed.
+	//
+	// This value is a Go template, see the documentation for the available variables and functions.
+	//
+	// Alternatively (but deprecated), this value can be a simple string using one of the following
+	// placeholders:
 	//
 	//   - $remoteClusterName   -- the kcp workspace's cluster name (e.g. "1084s8ceexsehjm2")
 	//   - $remoteNamespace     -- the original namespace used by the consumer inside the kcp
@@ -131,6 +144,8 @@ type ResourceNaming struct {
 	//                             (rarely used to construct local namespace names)
 	//   - $remoteNameHash      -- first 20 hex characters of the SHA-1 hash of $remoteName
 	//
+	// Authors are advised to use Go templates instead, as the custom variable syntax is deprecated
+	// and will be removed from a future release of the Sync Agent.
 	Namespace string `json:"namespace,omitempty"`
 }
 

--- a/sdk/apis/syncagent/v1alpha1/published_resource.go
+++ b/sdk/apis/syncagent/v1alpha1/published_resource.go
@@ -217,8 +217,6 @@ type RelatedResourceObjectSpec struct {
 	Selector *RelatedResourceObjectSelector `json:"selector,omitempty"`
 	// Reference points to a field inside the main object. This reference is
 	// evaluated on both source and destination sides to find the related object.
-	//
-	// Deprecated: Use Go templates instead.
 	Reference *RelatedResourceObjectReference `json:"reference,omitempty"`
 	// Template is a Go templated string that can make use of variables to
 	// construct the resulting string.


### PR DESCRIPTION
## Summary
References are still kind of useful and compact. In a future version we want to allow to configure related resources where 1 primary object can contain references to many related objects (but the admin only configures 1). Since Go templates only ever result in a string, references suddenly offer a new advantage: The ability to select _and return_ multiple values at once.

## What Type of PR Is This?
/kind documentation

## Release Notes
```release-note
NONE
```
