### PR TITLE
Allow references to select multiple values

### DIFF
--- a/docs/content/publish-resources/index.md
+++ b/docs/content/publish-resources/index.md
@@ -303,20 +303,23 @@ existing" and not create an error.
 
 #### References
 
-A reference is a JSONPath-like expression that are evaluated on both sides of the synchronization.
-You configure a single path expression (like `spec.secretName`) and the sync agent will evaluate it
-in the original primary object (in kcp) and again in the copied primary object (on the service
-cluster). Since the primary object has already been mutated, the `spec.secretName` is already
-rewritten/adjusted to work on the service cluster (for example it was changed from `my-secret` to
-`jk23h4wz47329rz2r72r92-secret` on the service cluster side). By doing it this way, admins only have
-to think about mutations and rewrites once (when configuring the primary object in the
-PublishedResource) and the path will yield 2 ready to use values (`my-secret` and the computed value).
+A reference is a JSONPath-like expression (more precisely, it follows the [gjson syntax](https://github.com/tidwall/gjson?tab=readme-ov-file#path-syntax))
+that are evaluated on both sides of the synchronization. You configure a single path expression
+(like `spec.secretName`) and the sync agent will evaluate it in the original primary object (in kcp)
+and again in the copied primary object (on the service cluster). Since the primary object has already
+been mutated, the `spec.secretName` is already rewritten/adjusted to work on the service cluster
+(for example it was changed from `my-secret` to `jk23h4wz47329rz2r72r92-secret` on the service
+cluster side). By doing it this way, admins only have to think about mutations and rewrites once
+(when configuring the primary object in the PublishedResource) and the path will yield 2 ready to
+use values (`my-secret` and the computed value).
 
-The value selected by the path expression must be a string (or number, but it will be coalesced into
-a string) and can then be further adjusted by applying a regular expression to it.
+References can either return a single scalar (strings or integers that will be auto-converted to a
+string) (like in `spec.secretName`) or a list of strings/numbers (like `spec.users.#.name`). A
+reference must return the same number of items on both the local and remote object, otherwise the
+agent will not be able to map local related names to remote related names correctly.
 
-References can only ever select one related object. Their upside is that they are simple to understand
-and easy to use, but require a "link" in the primary object that would point to the related object.
+A regular expression can be configured to be applied to each found value (i.e. if the reference returns
+a list of values, the regular expression is applied to each individual value).
 
 Here's an example on how to use references to locate the related object.
 

--- a/docs/generators/crd-ref/crd.template.md
+++ b/docs/generators/crd-ref/crd.template.md
@@ -4,8 +4,8 @@ description: |
 {{- if .Description }}
 {{ .Description | indent 2 }}
 {{- else }}
-  Custom resource definition (CRD) schema reference page for the {{ .Title }} 
-  resource ({{ .NamePlural }}.{{ .Group }}), as part of the Giant Swarm 
+  Custom resource definition (CRD) schema reference page for the {{ .Title }}
+  resource ({{ .NamePlural }}.{{ .Group }}), as part of the Giant Swarm
   Management API documentation.
 {{- end }}
 weight: {{ .Weight }}
@@ -78,7 +78,7 @@ This CRD is being replaced by <a href="../{{ .FullName }}/">{{ .ShortName }}</a>
 </div>
 {{with .Description}}
 <div class="property-description">
-{{.|markdown}}
+{% raw %}{{.|markdown}}{% endraw %}
 </div>
 {{end}}
 </div>

--- a/test/crds/backup.go
+++ b/test/crds/backup.go
@@ -28,6 +28,11 @@ type Backup struct {
 }
 
 type BackupSpec struct {
-	Source      string `json:"source"`
-	Destination string `json:"destination"`
+	Source      string       `json:"source"`
+	Destination string       `json:"destination"`
+	Items       []BackupItem `json:"items,omitempty"`
+}
+
+type BackupItem struct {
+	Name string `json:"name"`
 }

--- a/test/crds/backup.yaml
+++ b/test/crds/backup.yaml
@@ -25,3 +25,10 @@ spec:
                   type: string
                 destination:
                   type: string
+                items:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      name:
+                        type: string


### PR DESCRIPTION
## Summary
So far the agent has 3 different modes for finding related objects:

* references
* templates
* label selectors

Only label selectors were currently able to handle many objects for 1 single related object configuration. This proved a bit too limitting.

This PR extends references to also allow to select multiple values. For this a query would look like `spec.users.#.name` to select all the names of all users in an object.

## What Type of PR Is This?
/kind feature

## Release Notes
```release-note
References can now return lists of values to allow a single related resource configuration to match many Kubernetes objects at once.
```
