### PR TITLE
Support APIExportEndpointSlices / kcp 0.28

### DIFF
--- a/.prow.yaml
+++ b/.prow.yaml
@@ -88,7 +88,7 @@ presubmits:
               memory: 4Gi
               cpu: 2
 
-  - name: pull-api-syncagent-test-e2e
+  - name: pull-api-syncagent-test-e2e-kcp-0.27
     always_run: true
     decorate: true
     clone_uri: "https://github.com/kcp-dev/api-syncagent"
@@ -99,6 +99,31 @@ presubmits:
         - image: ghcr.io/kcp-dev/infra/build:1.24.3-1
           command:
             - hack/ci/run-e2e-tests.sh
+          env:
+            - name: KCP_TAG
+              value: '0.27.1'
+          resources:
+            requests:
+              memory: 4Gi
+              cpu: 2
+          # docker-in-docker needs privileged mode
+          securityContext:
+            privileged: true
+
+  - name: pull-api-syncagent-test-e2e-kcp-0.28
+    always_run: true
+    decorate: true
+    clone_uri: "https://github.com/kcp-dev/api-syncagent"
+    labels:
+      preset-goproxy: "true"
+    spec:
+      containers:
+        - image: ghcr.io/kcp-dev/infra/build:1.24.3-1
+          command:
+            - hack/ci/run-e2e-tests.sh
+          env:
+            - name: KCP_TAG
+              value: '0.28.1'
           resources:
             requests:
               memory: 4Gi

--- a/.prow.yaml
+++ b/.prow.yaml
@@ -106,9 +106,6 @@ presubmits:
             requests:
               memory: 4Gi
               cpu: 2
-          # docker-in-docker needs privileged mode
-          securityContext:
-            privileged: true
 
   - name: pull-api-syncagent-test-e2e-kcp-0.28
     always_run: true
@@ -128,6 +125,3 @@ presubmits:
             requests:
               memory: 4Gi
               cpu: 2
-          # docker-in-docker needs privileged mode
-          securityContext:
-            privileged: true

--- a/.prow.yaml
+++ b/.prow.yaml
@@ -100,7 +100,7 @@ presubmits:
           command:
             - hack/ci/run-e2e-tests.sh
           env:
-            - name: KCP_TAG
+            - name: KCP_VERSION
               value: '0.27.1'
           resources:
             requests:
@@ -119,7 +119,7 @@ presubmits:
           command:
             - hack/ci/run-e2e-tests.sh
           env:
-            - name: KCP_TAG
+            - name: KCP_VERSION
               value: '0.28.1'
           resources:
             requests:

--- a/Makefile
+++ b/Makefile
@@ -98,7 +98,7 @@ $(YQ):
 	  yq_*
 
 KCP = _tools/kcp
-KCP_VERSION = 0.28.1
+KCP_VERSION ?= 0.28.1
 
 .PHONY: $(KCP)
 $(KCP):

--- a/Makefile
+++ b/Makefile
@@ -98,7 +98,7 @@ $(YQ):
 	  yq_*
 
 KCP = _tools/kcp
-KCP_VERSION = 0.27.1
+KCP_VERSION = 0.28.1
 
 .PHONY: $(KCP)
 $(KCP):

--- a/cmd/api-syncagent/kcp.go
+++ b/cmd/api-syncagent/kcp.go
@@ -22,8 +22,9 @@ import (
 	"fmt"
 	"regexp"
 
-	"github.com/kcp-dev/api-syncagent/internal/kcp"
 	"github.com/kcp-dev/logicalcluster/v3"
+
+	"github.com/kcp-dev/api-syncagent/internal/kcp"
 
 	kcpdevv1alpha1 "github.com/kcp-dev/kcp/sdk/apis/apis/v1alpha1"
 	kcpdevcore "github.com/kcp-dev/kcp/sdk/apis/core"
@@ -53,7 +54,7 @@ import (
 // either the APIExport or the APIExportEndpointSlice.
 func setupEndpointKcpCluster(endpoint *syncEndpoint) (cluster.Cluster, error) {
 	// no need for a dedicated endpoint cluster
-	if endpoint.APIExport.Cluster == endpoint.EndpointSlice.Cluster {
+	if endpoint.EndpointSlice == nil || endpoint.EndpointSlice.Cluster == endpoint.APIExport.Cluster {
 		return nil, nil
 	}
 

--- a/cmd/api-syncagent/kcp.go
+++ b/cmd/api-syncagent/kcp.go
@@ -1,0 +1,293 @@
+/*
+Copyright 2025 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"regexp"
+
+	"github.com/kcp-dev/api-syncagent/internal/kcp"
+	"github.com/kcp-dev/logicalcluster/v3"
+
+	kcpdevv1alpha1 "github.com/kcp-dev/kcp/sdk/apis/apis/v1alpha1"
+	kcpdevcore "github.com/kcp-dev/kcp/sdk/apis/core"
+	kcpdevcorev1alpha1 "github.com/kcp-dev/kcp/sdk/apis/core/v1alpha1"
+
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/cluster"
+)
+
+// The agent has two potentially different kcp clusters:
+//
+//   endpointCluster - this is where the source of the virtual workspace URLs
+//                     live, i.e. where the APIExport/EndpointSlice.
+//   managedCluster  - this is where the APIExport and APIResourceSchemas
+//                     exist that are meant to be reconciled.
+//
+// The managedCluster always exists, the endpointCluster only if the workspace
+// for the virtual workspace source is different from the managed cluster.
+
+// setupEndpointKcpCluster sets up a plain, non-kcp-aware ctrl-runtime Cluster object
+// that is solvely used to watch whichever object holds the virtual workspace URLs,
+// either the APIExport or the APIExportEndpointSlice.
+func setupEndpointKcpCluster(endpoint *syncEndpoint) (cluster.Cluster, error) {
+	// no need for a dedicated endpoint cluster
+	if endpoint.APIExport.Cluster == endpoint.EndpointSlice.Cluster {
+		return nil, nil
+	}
+
+	scheme := runtime.NewScheme()
+
+	if err := kcpdevv1alpha1.AddToScheme(scheme); err != nil {
+		return nil, fmt.Errorf("failed to register scheme %s: %w", kcpdevv1alpha1.SchemeGroupVersion, err)
+	}
+
+	if err := kcpdevcorev1alpha1.AddToScheme(scheme); err != nil {
+		return nil, fmt.Errorf("failed to register scheme %s: %w", kcpdevcorev1alpha1.SchemeGroupVersion, err)
+	}
+
+	// RBAC in kcp might be very tight and might not allow to list/watch all objects;
+	// restrict the cache's selectors accordingly so we can still make use of caching.
+	byObject := map[ctrlruntimeclient.Object]cache.ByObject{
+		&kcpdevv1alpha1.APIExportEndpointSlice{}: {
+			Field: fields.SelectorFromSet(fields.Set{"metadata.name": endpoint.EndpointSlice.Name}),
+		},
+	}
+
+	return cluster.New(endpoint.EndpointSlice.Config, func(o *cluster.Options) {
+		o.Scheme = scheme
+		o.Cache = cache.Options{
+			Scheme:   scheme,
+			ByObject: byObject,
+		}
+	})
+}
+
+// setupManagedKcpCluster sets up a plain, non-kcp-aware ctrl-runtime Cluster object
+// that is solvely used to manage the APIExport and APIResourceSchemas.
+func setupManagedKcpCluster(endpoint *syncEndpoint) (cluster.Cluster, error) {
+	scheme := runtime.NewScheme()
+
+	if err := kcpdevv1alpha1.AddToScheme(scheme); err != nil {
+		return nil, fmt.Errorf("failed to register scheme %s: %w", kcpdevv1alpha1.SchemeGroupVersion, err)
+	}
+
+	if err := kcpdevcorev1alpha1.AddToScheme(scheme); err != nil {
+		return nil, fmt.Errorf("failed to register scheme %s: %w", kcpdevcorev1alpha1.SchemeGroupVersion, err)
+	}
+
+	// RBAC in kcp might be very tight and might not allow to list/watch all objects;
+	// restrict the cache's selectors accordingly so we can still make use of caching.
+	byObject := map[ctrlruntimeclient.Object]cache.ByObject{
+		&kcpdevv1alpha1.APIExport{}: {
+			Field: fields.SelectorFromSet(fields.Set{"metadata.name": endpoint.APIExport.Name}),
+		},
+	}
+
+	return cluster.New(endpoint.APIExport.Config, func(o *cluster.Options) {
+		o.Scheme = scheme
+		o.Cache = cache.Options{
+			Scheme:   scheme,
+			ByObject: byObject,
+		}
+	})
+}
+
+type qualifiedCluster struct {
+	Cluster logicalcluster.Name
+	Path    logicalcluster.Path
+	Config  *rest.Config
+}
+
+type qualifiedAPIExport struct {
+	*kcpdevv1alpha1.APIExport
+	qualifiedCluster
+}
+
+type qualifiedAPIExportEndpointSlice struct {
+	*kcpdevv1alpha1.APIExportEndpointSlice
+	qualifiedCluster
+}
+
+type syncEndpoint struct {
+	APIExport     qualifiedAPIExport
+	EndpointSlice *qualifiedAPIExportEndpointSlice
+}
+
+// resolveSyncEndpoint takes the user provided (usually via CLI flags) APIExportEndpointSliceRef and
+// APIExportRef and resolves, returning a consistent SyncEndpoint. The initialRestConfig must point
+// to the cluster where either of the two objects reside (i.e. if the APIExportRef is given, it
+// must point to the cluster where the APIExport lives, and vice versa for the endpoint slice;
+// however the endpoint slice references an APIExport in potentially another cluster, and for this
+// case the initialRestConfig will be rewritten accordingly).
+func resolveSyncEndpoint(ctx context.Context, initialRestConfig *rest.Config, endpointSliceRef string, apiExportRef string) (*syncEndpoint, error) {
+	// construct temporary, uncached client
+	scheme := runtime.NewScheme()
+	if err := kcpdevcorev1alpha1.AddToScheme(scheme); err != nil {
+		return nil, fmt.Errorf("failed to register scheme %s: %w", kcpdevcorev1alpha1.SchemeGroupVersion, err)
+	}
+	if err := kcpdevv1alpha1.AddToScheme(scheme); err != nil {
+		return nil, fmt.Errorf("failed to register scheme %s: %w", kcpdevv1alpha1.SchemeGroupVersion, err)
+	}
+
+	clientOpts := ctrlruntimeclient.Options{Scheme: scheme}
+	client, err := ctrlruntimeclient.New(initialRestConfig, clientOpts)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create service reader: %w", err)
+	}
+
+	se := &syncEndpoint{}
+
+	// When an endpoint ref is given, both the APIExportEndpointSlice and the APIExport must exist.
+	if endpointSliceRef != "" {
+		endpointSlice, err := resolveAPIExportEndpointSlice(ctx, client, endpointSliceRef)
+		if err != nil {
+			return nil, fmt.Errorf("failed to resolve APIExportEndpointSlice: %w", err)
+		}
+		endpointSlice.Config = initialRestConfig
+
+		// find the APIExport referenced not by the user (can't: both ref parameters to this function
+		// are mutually exclusive), but in the APIExportEndpointSlice.
+		restConfig, err := retargetRestConfig(initialRestConfig, endpointSlice.Spec.APIExport.Path)
+		if err != nil {
+			return nil, fmt.Errorf("failed to re-target the given kubeconfig to cluster %q: %w", endpointSlice.Spec.APIExport.Path, err)
+		}
+
+		client, err := ctrlruntimeclient.New(restConfig, clientOpts)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create service reader: %w", err)
+		}
+
+		apiExport, err := resolveAPIExport(ctx, client, endpointSlice.Spec.APIExport.Name)
+		if err != nil {
+			return nil, fmt.Errorf("failed to resolve APIExport: %w", err)
+		}
+		apiExport.Config = restConfig
+
+		se.APIExport = apiExport
+		se.EndpointSlice = &endpointSlice
+	} else { // if an export ref is given, the endpoint slice is optional (for compat with kcp <0.28)
+		apiExport, err := resolveAPIExport(ctx, client, apiExportRef)
+		if err != nil {
+			return nil, fmt.Errorf("failed to resolve APIExport: %w", err)
+		}
+		apiExport.Config = initialRestConfig
+
+		se.APIExport = apiExport
+
+		// try to find an endpoint slice in the same workspace with the same name as the APIExport
+		endpointSlice, err := resolveAPIExportEndpointSlice(ctx, client, apiExportRef)
+		if ctrlruntimeclient.IgnoreNotFound(err) != nil {
+			return nil, fmt.Errorf("failed to resolve APIExportEndpointSlice: %w", err)
+		} else if err == nil {
+			apiExport.Config = initialRestConfig
+			se.EndpointSlice = &endpointSlice
+		}
+	}
+
+	return se, nil
+}
+
+func resolveAPIExportEndpointSlice(ctx context.Context, client ctrlruntimeclient.Client, ref string) (qualifiedAPIExportEndpointSlice, error) {
+	endpointSlice := &kcpdevv1alpha1.APIExportEndpointSlice{}
+	key := types.NamespacedName{Name: ref}
+	if err := client.Get(ctx, key, endpointSlice); err != nil {
+		return qualifiedAPIExportEndpointSlice{}, fmt.Errorf("failed to get APIExportEndpointSlice %q: %w", ref, err)
+	}
+
+	lcName, lcPath, err := resolveCurrentCluster(ctx, client)
+	if err != nil {
+		return qualifiedAPIExportEndpointSlice{}, fmt.Errorf("failed to resolve APIExportEndpointSlice cluster: %w", err)
+	}
+
+	return qualifiedAPIExportEndpointSlice{
+		APIExportEndpointSlice: endpointSlice,
+		qualifiedCluster: qualifiedCluster{
+			Cluster: lcName,
+			Path:    lcPath,
+		},
+	}, nil
+}
+
+func resolveAPIExport(ctx context.Context, client ctrlruntimeclient.Client, ref string) (qualifiedAPIExport, error) {
+	apiExport := &kcpdevv1alpha1.APIExport{}
+	key := types.NamespacedName{Name: ref}
+	if err := client.Get(ctx, key, apiExport); err != nil {
+		return qualifiedAPIExport{}, fmt.Errorf("failed to get APIExport %q: %w", ref, err)
+	}
+
+	lcName, lcPath, err := resolveCurrentCluster(ctx, client)
+	if err != nil {
+		return qualifiedAPIExport{}, fmt.Errorf("failed to resolve APIExport cluster: %w", err)
+	}
+
+	return qualifiedAPIExport{
+		APIExport: apiExport,
+		qualifiedCluster: qualifiedCluster{
+			Cluster: lcName,
+			Path:    lcPath,
+		},
+	}, nil
+}
+
+func resolveCurrentCluster(ctx context.Context, client ctrlruntimeclient.Client) (logicalcluster.Name, logicalcluster.Path, error) {
+	lc := &kcpdevcorev1alpha1.LogicalCluster{}
+	if err := client.Get(ctx, types.NamespacedName{Name: kcp.IdentityClusterName}, lc); err != nil {
+		return "", logicalcluster.None, fmt.Errorf("failed to resolve current workspace: %w", err)
+	}
+
+	lcName := logicalcluster.From(lc)
+	lcPath := logicalcluster.NewPath(lc.Annotations[kcpdevcore.LogicalClusterPathAnnotationKey])
+
+	return lcName, lcPath, nil
+}
+
+var clusterFinder = regexp.MustCompile(`/clusters/([^/]+)`)
+
+func retargetRestConfig(cfg *rest.Config, destination string) (*rest.Config, error) {
+	// no change desired (use current cluster implicitly)
+	if destination == "" {
+		return cfg, nil
+	}
+
+	matches := clusterFinder.FindAllStringSubmatch(cfg.Host, -1)
+	if len(matches) == 0 {
+		return nil, errors.New("URL must point to a cluster/workspace")
+	}
+	if len(matches) > 1 {
+		return nil, errors.New("invalid URL: URL contains more than one cluster path")
+	}
+
+	current := matches[0][1]
+	if current == destination {
+		return cfg, nil
+	}
+
+	newCluster := fmt.Sprintf("/clusters/%s", destination)
+
+	newConfig := rest.CopyConfig(cfg)
+	newConfig.Host = clusterFinder.ReplaceAllString(cfg.Host, newCluster)
+
+	return newConfig, nil
+}

--- a/cmd/api-syncagent/main.go
+++ b/cmd/api-syncagent/main.go
@@ -36,6 +36,8 @@ import (
 	"github.com/kcp-dev/api-syncagent/internal/version"
 	syncagentv1alpha1 "github.com/kcp-dev/api-syncagent/sdk/apis/syncagent/v1alpha1"
 
+	kcpdevv1alpha1 "github.com/kcp-dev/kcp/sdk/apis/apis/v1alpha1"
+
 	corev1 "k8s.io/api/core/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -177,10 +179,15 @@ func run(ctx context.Context, log *zap.SugaredLogger, opts *Options) error {
 			cluster = managedKcpCluster
 		}
 
+		var endpointSlice *kcpdevv1alpha1.APIExportEndpointSlice
+		if endpoint.EndpointSlice != nil {
+			endpointSlice = endpoint.EndpointSlice.APIExportEndpointSlice
+		}
+
 		// It doesn't matter which rest config we specify, as the URL will be overwritten with the
 		// virtual workspace URL anyway.
 
-		return syncmanager.Add(ctx, mgr, cluster, kcpRestConfig, log, endpoint.APIExport.APIExport, endpoint.EndpointSlice.APIExportEndpointSlice, opts.PublishedResourceSelector, opts.Namespace, opts.AgentName)
+		return syncmanager.Add(ctx, mgr, cluster, kcpRestConfig, log, endpoint.APIExport.APIExport, endpointSlice, opts.PublishedResourceSelector, opts.Namespace, opts.AgentName)
 	}); err != nil {
 		return err
 	}

--- a/cmd/api-syncagent/main.go
+++ b/cmd/api-syncagent/main.go
@@ -25,7 +25,6 @@ import (
 	"strings"
 
 	"github.com/go-logr/zapr"
-	"github.com/kcp-dev/logicalcluster/v3"
 	"github.com/spf13/pflag"
 	"go.uber.org/zap"
 	reconcilerlog "k8c.io/reconciler/pkg/log"
@@ -33,27 +32,17 @@ import (
 	"github.com/kcp-dev/api-syncagent/internal/controller/apiexport"
 	"github.com/kcp-dev/api-syncagent/internal/controller/apiresourceschema"
 	"github.com/kcp-dev/api-syncagent/internal/controller/syncmanager"
-	"github.com/kcp-dev/api-syncagent/internal/kcp"
 	syncagentlog "github.com/kcp-dev/api-syncagent/internal/log"
 	"github.com/kcp-dev/api-syncagent/internal/version"
 	syncagentv1alpha1 "github.com/kcp-dev/api-syncagent/sdk/apis/syncagent/v1alpha1"
 
-	kcpdevv1alpha1 "github.com/kcp-dev/kcp/sdk/apis/apis/v1alpha1"
-	kcpdevcore "github.com/kcp-dev/kcp/sdk/apis/core"
-	kcpdevcorev1alpha1 "github.com/kcp-dev/kcp/sdk/apis/core/v1alpha1"
-
 	corev1 "k8s.io/api/core/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
-	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	ctrlruntime "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/cache"
-	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/cluster"
 	ctrlruntimelog "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
@@ -117,24 +106,42 @@ func run(ctx context.Context, log *zap.SugaredLogger, opts *Options) error {
 		return fmt.Errorf("kcp kubeconfig does not point to a specific workspace")
 	}
 
-	// We check if the APIExport exists and extract information we need to set up our kcpCluster.
-	apiExport, lcPath, lcName, err := resolveAPIExport(ctx, kcpRestConfig, opts.APIExportRef)
+	// We check if the APIExport/APIExportEndpointSlice exists and extract information we need to set up our kcpCluster.
+	endpoint, err := resolveSyncEndpoint(ctx, kcpRestConfig, opts.APIExportEndpointSliceRef, opts.APIExportRef)
 	if err != nil {
-		return fmt.Errorf("failed to resolve APIExport: %w", err)
+		return fmt.Errorf("failed to resolve APIExport/EndpointSlice: %w", err)
 	}
 
-	log.Infow("Resolved APIExport", "workspace", lcPath, "logicalcluster", lcName)
+	log.Infow("Resolved APIExport", "workspace", endpoint.APIExport.Path, "logicalcluster", endpoint.APIExport.Cluster)
 
-	// init the "permanent" kcp cluster connection
-	kcpCluster, err := setupKcpCluster(kcpRestConfig, opts)
+	if s := endpoint.EndpointSlice; s != nil {
+		log.Infow("Using APIExportEndpointSlice", "workspace", s.Path, "logicalcluster", s.Cluster)
+	}
+
+	// init the "permanent" kcp cluster connections
+
+	// always need the managedKcpCluster
+	managedKcpCluster, err := setupManagedKcpCluster(endpoint)
 	if err != nil {
-		return fmt.Errorf("failed to initialize kcp cluster: %w", err)
+		return fmt.Errorf("failed to initialize managed kcp cluster: %w", err)
 	}
 
 	// start the kcp cluster caches when the manager boots up
 	// (happens regardless of leader election status)
-	if err := mgr.Add(kcpCluster); err != nil {
-		return fmt.Errorf("failed to add kcp cluster runnable: %w", err)
+	if err := mgr.Add(managedKcpCluster); err != nil {
+		return fmt.Errorf("failed to add managed kcp cluster runnable: %w", err)
+	}
+
+	// the endpoint cluster can be nil
+	endpointKcpCluster, err := setupEndpointKcpCluster(endpoint)
+	if err != nil {
+		return fmt.Errorf("failed to initialize endpoint kcp cluster: %w", err)
+	}
+
+	if endpointKcpCluster != nil {
+		if err := mgr.Add(endpointKcpCluster); err != nil {
+			return fmt.Errorf("failed to add endpoint kcp cluster runnable: %w", err)
+		}
 	}
 
 	startController := func(name string, creator func() error) error {
@@ -151,13 +158,13 @@ func run(ctx context.Context, log *zap.SugaredLogger, opts *Options) error {
 	}
 
 	if err := startController("apiresourceschema", func() error {
-		return apiresourceschema.Add(mgr, kcpCluster, lcName, log, 4, opts.AgentName, opts.PublishedResourceSelector)
+		return apiresourceschema.Add(mgr, managedKcpCluster, endpoint.APIExport.Cluster, log, 4, opts.AgentName, opts.PublishedResourceSelector)
 	}); err != nil {
 		return err
 	}
 
 	if err := startController("apiexport", func() error {
-		return apiexport.Add(mgr, kcpCluster, lcName, log, opts.APIExportRef, opts.AgentName, opts.PublishedResourceSelector)
+		return apiexport.Add(mgr, managedKcpCluster, endpoint.APIExport.Cluster, log, opts.APIExportRef, opts.AgentName, opts.PublishedResourceSelector)
 	}); err != nil {
 		return err
 	}
@@ -165,7 +172,15 @@ func run(ctx context.Context, log *zap.SugaredLogger, opts *Options) error {
 	// This controller is called "sync" because it makes the most sense to the users, even though internally the relevant
 	// controller is the syncmanager (which in turn would start/stop the sync controllers).
 	if err := startController("sync", func() error {
-		return syncmanager.Add(ctx, mgr, kcpCluster, kcpRestConfig, log, apiExport, opts.PublishedResourceSelector, opts.Namespace, opts.AgentName)
+		cluster := endpointKcpCluster
+		if cluster == nil {
+			cluster = managedKcpCluster
+		}
+
+		// It doesn't matter which rest config we specify, as the URL will be overwritten with the
+		// virtual workspace URL anyway.
+
+		return syncmanager.Add(ctx, mgr, cluster, kcpRestConfig, log, endpoint.APIExport.APIExport, endpoint.EndpointSlice.APIExportEndpointSlice, opts.PublishedResourceSelector, opts.Namespace, opts.AgentName)
 	}); err != nil {
 		return err
 	}
@@ -219,74 +234,6 @@ func setupLocalManager(ctx context.Context, opts *Options) (manager.Manager, err
 	}
 
 	return mgr, nil
-}
-
-func resolveAPIExport(ctx context.Context, restConfig *rest.Config, apiExportRef string) (*kcpdevv1alpha1.APIExport, logicalcluster.Path, logicalcluster.Name, error) {
-	// construct temporary, uncached client
-	scheme := runtime.NewScheme()
-	if err := kcpdevcorev1alpha1.AddToScheme(scheme); err != nil {
-		return nil, logicalcluster.None, "", fmt.Errorf("failed to register scheme %s: %w", kcpdevcorev1alpha1.SchemeGroupVersion, err)
-	}
-	if err := kcpdevv1alpha1.AddToScheme(scheme); err != nil {
-		return nil, logicalcluster.None, "", fmt.Errorf("failed to register scheme %s: %w", kcpdevv1alpha1.SchemeGroupVersion, err)
-	}
-
-	client, err := ctrlruntimeclient.New(restConfig, ctrlruntimeclient.Options{
-		Scheme: scheme,
-	})
-	if err != nil {
-		return nil, logicalcluster.None, "", fmt.Errorf("failed to create service reader: %w", err)
-	}
-
-	apiExport := &kcpdevv1alpha1.APIExport{}
-	key := types.NamespacedName{Name: apiExportRef}
-	if err := client.Get(ctx, key, apiExport); err != nil {
-		return nil, logicalcluster.None, "", fmt.Errorf("failed to get APIExport %q: %w", apiExportRef, err)
-	}
-
-	// kcp's controller-runtime fork always caches objects including their logicalcluster names.
-	// Our app technically doesn't care about workspaces / logical clusters, but we still need to
-	// supply the correct logicalcluster when querying for objects.
-	// We could take the cluster name from the Service itself, but since we want to log the nicer
-	// looking cluster _path_, we fetch the workspace's own logicalcluster object.
-	lc := &kcpdevcorev1alpha1.LogicalCluster{}
-	key = types.NamespacedName{Name: kcp.IdentityClusterName}
-	if err := client.Get(ctx, key, lc); err != nil {
-		return nil, logicalcluster.None, "", fmt.Errorf("failed to resolve current workspace: %w", err)
-	}
-
-	lcName := logicalcluster.From(lc)
-	lcPath := logicalcluster.NewPath(lc.Annotations[kcpdevcore.LogicalClusterPathAnnotationKey])
-
-	return apiExport, lcPath, lcName, nil
-}
-
-// setupKcpCluster sets up a plain, non-kcp-aware ctrl-runtime Cluster object
-// that is solvely used to interact with the APIExport and APIResourceSchemas.
-func setupKcpCluster(restConfig *rest.Config, opts *Options) (cluster.Cluster, error) {
-	scheme := runtime.NewScheme()
-
-	if err := kcpdevv1alpha1.AddToScheme(scheme); err != nil {
-		return nil, fmt.Errorf("failed to register scheme %s: %w", kcpdevv1alpha1.SchemeGroupVersion, err)
-	}
-
-	if err := kcpdevcorev1alpha1.AddToScheme(scheme); err != nil {
-		return nil, fmt.Errorf("failed to register scheme %s: %w", kcpdevcorev1alpha1.SchemeGroupVersion, err)
-	}
-
-	return cluster.New(restConfig, func(o *cluster.Options) {
-		o.Scheme = scheme
-		// RBAC in kcp might be very tight and might not allow to list/watch all objects;
-		// restrict the cache's selectors accordingly so we can still make use of caching.
-		o.Cache = cache.Options{
-			Scheme: scheme,
-			ByObject: map[ctrlruntimeclient.Object]cache.ByObject{
-				&kcpdevv1alpha1.APIExport{}: {
-					Field: fields.SelectorFromSet(fields.Set{"metadata.name": opts.APIExportRef}),
-				},
-			},
-		}
-	})
 }
 
 func loadKubeconfig(filename string) (*rest.Config, error) {

--- a/docs/content/publish-resources/index.md
+++ b/docs/content/publish-resources/index.md
@@ -2,8 +2,8 @@
 
 The guide describes the process of making a resource (usually defined by a CustomResourceDefinition)
 of one Kubernetes cluster (the "service cluster" or "local cluster") available for use in kcp. This
-involves setting up an `APIExport` and then installing the Sync Agent and defining
-`PublishedResources` in the local cluster.
+involves setting up an `APIExport`, potentially an `APIExportEndpointSlice` and then installing the
+Sync Agent and defining `PublishedResources` in the local cluster.
 
 All of the documentation and API types are worded and named from the perspective of a service owner,
 the person(s) who own a service and want to make it available to consumers in kcp.
@@ -23,7 +23,7 @@ versions and even change API group, versions and names in transit (for example p
 the service cluster as v1beta1 within kcp). This process of changing the identity of a CRD is called
 "projection" in the agent.
 
-All published resources together form the APIExport. When a service is enabled in a workspace
+All published resources together form the `APIExport`. When a service is enabled in a workspace
 (i.e. it is bound to it), users can manage objects for the projected resources described by the
 published resources. These objects will be synced from the workspace onto the service cluster,
 where they are meant to be processed in whatever way the service owners desire. Any possible

--- a/internal/controller/syncmanager/controller.go
+++ b/internal/controller/syncmanager/controller.go
@@ -18,7 +18,6 @@ package syncmanager
 
 import (
 	"context"
-	"errors"
 	"fmt"
 
 	"go.uber.org/zap"
@@ -74,7 +73,7 @@ type Reconciler struct {
 	stateNamespace  string
 	agentName       string
 
-	// only one of these two must be set
+	// endpointSlice is preferred over apiExport
 	apiExport     *kcpapisv1alpha1.APIExport
 	endpointSlice *kcpapisv1alpha1.APIExportEndpointSlice
 
@@ -105,8 +104,6 @@ type syncWorker struct {
 }
 
 // Add creates a new controller and adds it to the given manager.
-//
-// Only one of apiExport and endpointSlice must be given.
 func Add(
 	ctx context.Context,
 	localManager manager.Manager,
@@ -119,13 +116,6 @@ func Add(
 	stateNamespace string,
 	agentName string,
 ) error {
-	if apiExport != nil && endpointSlice != nil {
-		return errors.New("this controller works either with APIExport or APIExportEndpointSlice, not both")
-	}
-	if apiExport == nil && endpointSlice == nil {
-		return errors.New("neither APIExport nor APIExportEndpointSlice provided")
-	}
-
 	discoveryClient, err := discovery.NewClient(localManager.GetConfig())
 	if err != nil {
 		return fmt.Errorf("failed to create discovery client: %w", err)

--- a/test/e2e/sync/apiexportendpointslice_test.go
+++ b/test/e2e/sync/apiexportendpointslice_test.go
@@ -122,6 +122,14 @@ func TestAPIExportEndpointSliceSameCluster(t *testing.T) {
 		Resource: "crontabs",
 	})
 
+	// In kcp 0.27, the binding' status is not perfectly in-sync with the actual APIs available in
+	// the workspace; since this is fixed in 0.28+ and we really care about the APIBinding, not necessarily
+	// the Kubernetes magic behind it, we keep the loop above but on 0.27 add a small synthetic delay.
+	// TODO: Remove this once we do not support kcp 0.27 anymore.
+	if utils.KCPMinor() < 28 {
+		time.Sleep(2 * time.Second)
+	}
+
 	// create a Crontab object in a team workspace
 	t.Log("Creating CronTab in kcp…")
 	crontab := utils.YAMLToUnstructured(t, `
@@ -257,6 +265,11 @@ func TestAPIExportEndpointSliceDifferentCluster(t *testing.T) {
 		Version:  "v1",
 		Resource: "crontabs",
 	})
+
+	// TODO: Remove this once we do not support kcp 0.27 anymore.
+	if utils.KCPMinor() < 28 {
+		time.Sleep(2 * time.Second)
+	}
 
 	// create a Crontab object in a team workspace
 	t.Log("Creating CronTab in kcp…")

--- a/test/e2e/sync/apiexportendpointslice_test.go
+++ b/test/e2e/sync/apiexportendpointslice_test.go
@@ -1,0 +1,134 @@
+//go:build e2e
+
+/*
+Copyright 2025 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sync
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/go-logr/logr"
+	"github.com/kcp-dev/logicalcluster/v3"
+
+	syncagentv1alpha1 "github.com/kcp-dev/api-syncagent/sdk/apis/syncagent/v1alpha1"
+	"github.com/kcp-dev/api-syncagent/test/utils"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
+	ctrlruntime "sigs.k8s.io/controller-runtime"
+)
+
+// TestAPIExportEndpointSlice is functionally equivalent to a simple sync test,
+// but is bootstrapping the agent using a AEES ref instead of an APIExport ref.
+func TestAPIExportEndpointSliceSameCluster(t *testing.T) {
+	const (
+		apiExportName = "kcp.example.com"
+		kcpGroupName  = "kcp.example.com"
+		orgWorkspace  = "endpointslice-same-cluster"
+	)
+
+	ctx := t.Context()
+	ctrlruntime.SetLogger(logr.Discard())
+
+	// setup a test environment in kcp
+	orgKubconfig := utils.CreateOrganization(t, ctx, orgWorkspace, apiExportName)
+
+	// start a service cluster
+	envtestKubeconfig, envtestClient, _ := utils.RunEnvtest(t, []string{
+		"test/crds/crontab.yaml",
+	})
+
+	// publish Crontabs and Backups
+	t.Logf("Publishing CRDs…")
+	prCrontabs := &syncagentv1alpha1.PublishedResource{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "publish-crontabs",
+		},
+		Spec: syncagentv1alpha1.PublishedResourceSpec{
+			Resource: syncagentv1alpha1.SourceResourceDescriptor{
+				APIGroup: "example.com",
+				Version:  "v1",
+				Kind:     "CronTab",
+			},
+			// These rules make finding the local object easier, but should not be used in production.
+			Naming: &syncagentv1alpha1.ResourceNaming{
+				Name:      "{{ .Object.metadata.name }}",
+				Namespace: "synced-{{ .Object.metadata.namespace }}",
+			},
+			Projection: &syncagentv1alpha1.ResourceProjection{
+				Group: kcpGroupName,
+			},
+		},
+	}
+
+	if err := envtestClient.Create(ctx, prCrontabs); err != nil {
+		t.Fatalf("Failed to create PublishedResource: %v", err)
+	}
+
+	// start the agent in the background to update the APIExport with the CronTabs API;
+	// use the export's name because kcp created an endpoint slice of the same name
+	utils.RunEndpointSliceAgent(ctx, t, "bob", orgKubconfig, envtestKubeconfig, apiExportName)
+
+	// wait until the API is available
+	kcpClusterClient := utils.GetKcpAdminClusterClient(t)
+
+	teamClusterPath := logicalcluster.NewPath("root").Join(orgWorkspace).Join("team-1")
+	teamClient := kcpClusterClient.Cluster(teamClusterPath)
+
+	utils.WaitForBoundAPI(t, ctx, teamClient, schema.GroupVersionResource{
+		Group:    kcpGroupName,
+		Version:  "v1",
+		Resource: "crontabs",
+	})
+
+	// create a Crontab object in a team workspace
+	t.Log("Creating CronTab in kcp…")
+	crontab := utils.YAMLToUnstructured(t, `
+apiVersion: kcp.example.com/v1
+kind: CronTab
+metadata:
+  namespace: default
+  name: my-crontab
+spec:
+  cronSpec: '* * *'
+  image: ubuntu:latest
+`)
+
+	if err := teamClient.Create(ctx, crontab); err != nil {
+		t.Fatalf("Failed to create CronTab in kcp: %v", err)
+	}
+
+	// wait for the agent to sync the object down into the service cluster
+
+	t.Logf("Wait for CronTab to be synced…")
+	copy := &unstructured.Unstructured{}
+	copy.SetAPIVersion("example.com/v1")
+	copy.SetKind("CronTab")
+
+	err := wait.PollUntilContextTimeout(ctx, 500*time.Millisecond, 30*time.Second, false, func(ctx context.Context) (done bool, err error) {
+		copyKey := types.NamespacedName{Namespace: "synced-default", Name: "my-crontab"}
+		return envtestClient.Get(ctx, copyKey, copy) == nil, nil
+	})
+	if err != nil {
+		t.Fatalf("Failed to wait for object to be synced down: %v", err)
+	}
+}

--- a/test/e2e/sync/apiexportendpointslice_test.go
+++ b/test/e2e/sync/apiexportendpointslice_test.go
@@ -20,6 +20,7 @@ package sync
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
@@ -29,6 +30,9 @@ import (
 	syncagentv1alpha1 "github.com/kcp-dev/api-syncagent/sdk/apis/syncagent/v1alpha1"
 	"github.com/kcp-dev/api-syncagent/test/utils"
 
+	kcpdevv1alpha1 "github.com/kcp-dev/kcp/sdk/apis/apis/v1alpha1"
+
+	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -90,6 +94,142 @@ func TestAPIExportEndpointSliceSameCluster(t *testing.T) {
 
 	// wait until the API is available
 	kcpClusterClient := utils.GetKcpAdminClusterClient(t)
+
+	teamClusterPath := logicalcluster.NewPath("root").Join(orgWorkspace).Join("team-1")
+	teamClient := kcpClusterClient.Cluster(teamClusterPath)
+
+	utils.WaitForBoundAPI(t, ctx, teamClient, schema.GroupVersionResource{
+		Group:    kcpGroupName,
+		Version:  "v1",
+		Resource: "crontabs",
+	})
+
+	// create a Crontab object in a team workspace
+	t.Log("Creating CronTab in kcp…")
+	crontab := utils.YAMLToUnstructured(t, `
+apiVersion: kcp.example.com/v1
+kind: CronTab
+metadata:
+  namespace: default
+  name: my-crontab
+spec:
+  cronSpec: '* * *'
+  image: ubuntu:latest
+`)
+
+	if err := teamClient.Create(ctx, crontab); err != nil {
+		t.Fatalf("Failed to create CronTab in kcp: %v", err)
+	}
+
+	// wait for the agent to sync the object down into the service cluster
+
+	t.Logf("Wait for CronTab to be synced…")
+	copy := &unstructured.Unstructured{}
+	copy.SetAPIVersion("example.com/v1")
+	copy.SetKind("CronTab")
+
+	err := wait.PollUntilContextTimeout(ctx, 500*time.Millisecond, 30*time.Second, false, func(ctx context.Context) (done bool, err error) {
+		copyKey := types.NamespacedName{Namespace: "synced-default", Name: "my-crontab"}
+		return envtestClient.Get(ctx, copyKey, copy) == nil, nil
+	})
+	if err != nil {
+		t.Fatalf("Failed to wait for object to be synced down: %v", err)
+	}
+}
+
+func TestAPIExportEndpointSliceDifferentCluster(t *testing.T) {
+	const (
+		apiExportName     = "kcp.example.com"
+		kcpGroupName      = "kcp.example.com"
+		orgWorkspace      = "endpointslice-different-cluster"
+		endpointWorkspace = "endpoint"
+	)
+
+	ctx := t.Context()
+	ctrlruntime.SetLogger(logr.Discard())
+
+	// setup a test environment in kcp
+	rootCluster := logicalcluster.NewPath("root")
+	utils.CreateOrganization(t, ctx, orgWorkspace, apiExportName)
+
+	// create a custom AEES in a different cluster than the APIExport
+	kcpClusterClient := utils.GetKcpAdminClusterClient(t)
+	orgClient := kcpClusterClient.Cluster(rootCluster.Join(orgWorkspace))
+	endpointClusterName := utils.CreateWorkspace(t, ctx, orgClient, endpointWorkspace)
+	endpointClient := kcpClusterClient.Cluster(endpointClusterName.Path())
+
+	endpointSlice := &kcpdevv1alpha1.APIExportEndpointSlice{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "dummy",
+		},
+		Spec: kcpdevv1alpha1.APIExportEndpointSliceSpec{
+			APIExport: kcpdevv1alpha1.ExportBindingReference{
+				Path: rootCluster.Join(orgWorkspace).String(),
+				Name: apiExportName,
+			},
+		},
+	}
+
+	t.Logf("Creating APIExportEndpointSlice %q…", endpointSlice.Name)
+	if err := endpointClient.Create(ctx, endpointSlice); err != nil {
+		t.Fatalf("Failed to create APIExportEndpointSlice: %v", err)
+	}
+
+	agent := rbacv1.Subject{
+		Kind: "User",
+		Name: "api-syncagent-e2e",
+	}
+
+	utils.GrantWorkspaceAccess(t, ctx, endpointClient, agent, rbacv1.PolicyRule{
+		APIGroups:     []string{"core.kcp.io"},
+		Resources:     []string{"logicalclusters"},
+		ResourceNames: []string{"cluster"},
+		Verbs:         []string{"get"},
+	}, rbacv1.PolicyRule{
+		APIGroups:     []string{"apis.kcp.io"},
+		Resources:     []string{"apiexportendpointslices"},
+		ResourceNames: []string{endpointSlice.Name},
+		Verbs:         []string{"get", "list", "watch"},
+	})
+
+	endpointKubeconfig := utils.CreateKcpAgentKubeconfig(t, fmt.Sprintf("/clusters/%s", endpointClusterName))
+
+	// start a service cluster
+	envtestKubeconfig, envtestClient, _ := utils.RunEnvtest(t, []string{
+		"test/crds/crontab.yaml",
+	})
+
+	// publish Crontabs and Backups
+	t.Logf("Publishing CRDs…")
+	prCrontabs := &syncagentv1alpha1.PublishedResource{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "publish-crontabs",
+		},
+		Spec: syncagentv1alpha1.PublishedResourceSpec{
+			Resource: syncagentv1alpha1.SourceResourceDescriptor{
+				APIGroup: "example.com",
+				Version:  "v1",
+				Kind:     "CronTab",
+			},
+			// These rules make finding the local object easier, but should not be used in production.
+			Naming: &syncagentv1alpha1.ResourceNaming{
+				Name:      "{{ .Object.metadata.name }}",
+				Namespace: "synced-{{ .Object.metadata.namespace }}",
+			},
+			Projection: &syncagentv1alpha1.ResourceProjection{
+				Group: kcpGroupName,
+			},
+		},
+	}
+
+	if err := envtestClient.Create(ctx, prCrontabs); err != nil {
+		t.Fatalf("Failed to create PublishedResource: %v", err)
+	}
+
+	// start the agent in the background to update the APIExport with the CronTabs API
+	utils.RunEndpointSliceAgent(ctx, t, "bob", endpointKubeconfig, envtestKubeconfig, endpointSlice.Name)
+
+	// wait until the API is available
 
 	teamClusterPath := logicalcluster.NewPath("root").Join(orgWorkspace).Join("team-1")
 	teamClient := kcpClusterClient.Cluster(teamClusterPath)

--- a/test/utils/fixtures.go
+++ b/test/utils/fixtures.go
@@ -129,18 +129,6 @@ func CreateAPIExport(t *testing.T, ctx context.Context, client ctrlruntimeclient
 		t.Fatalf("Failed to create APIExport: %v", err)
 	}
 
-	err := wait.PollUntilContextTimeout(ctx, 500*time.Millisecond, 30*time.Second, false, func(ctx context.Context) (done bool, err error) {
-		err = client.Get(ctx, ctrlruntimeclient.ObjectKeyFromObject(apiExport), apiExport)
-		if err != nil {
-			return false, err
-		}
-
-		return conditions.IsTrue(apiExport, kcpapisv1alpha1.APIExportVirtualWorkspaceURLsReady), nil
-	})
-	if err != nil {
-		t.Fatalf("Failed to wait for APIExport virtual workspace to become ready: %v", err)
-	}
-
 	// grant permissions to access/manage the APIExport
 	if rbacSubject != nil {
 		clusterRoleName := "api-syncagent"

--- a/test/utils/fixtures.go
+++ b/test/utils/fixtures.go
@@ -162,6 +162,11 @@ func CreateAPIExport(t *testing.T, ctx context.Context, client ctrlruntimeclient
 				},
 				{
 					APIGroups: []string{"apis.kcp.io"},
+					Resources: []string{"apiexportendpointslices"},
+					Verbs:     []string{"get", "list", "watch"},
+				},
+				{
+					APIGroups: []string{"apis.kcp.io"},
 					Resources: []string{"apiresourceschemas"},
 					Verbs:     []string{"get", "list", "watch", "create"},
 				},

--- a/test/utils/process.go
+++ b/test/utils/process.go
@@ -68,6 +68,17 @@ func uniqueLogfile(t *testing.T, basename string) string {
 	return fmt.Sprintf("%s_%02d.log", testName, counter)
 }
 
+func RunEndpointSliceAgent(
+	ctx context.Context,
+	t *testing.T,
+	name string,
+	kcpKubeconfig string,
+	localKubeconfig string,
+	apiExportEndpointSlice string,
+) context.CancelFunc {
+	return runAgent(ctx, t, name, kcpKubeconfig, localKubeconfig, "--apiexportendpointslice-ref", apiExportEndpointSlice)
+}
+
 func RunAgent(
 	ctx context.Context,
 	t *testing.T,
@@ -76,13 +87,25 @@ func RunAgent(
 	localKubeconfig string,
 	apiExport string,
 ) context.CancelFunc {
+	return runAgent(ctx, t, name, kcpKubeconfig, localKubeconfig, "--apiexport-ref", apiExport)
+}
+
+func runAgent(
+	ctx context.Context,
+	t *testing.T,
+	name string,
+	kcpKubeconfig string,
+	localKubeconfig string,
+	refFlag string,
+	refValue string,
+) context.CancelFunc {
 	t.Helper()
 
 	t.Logf("Running agent %q…", name)
 
 	args := []string{
 		"--agent-name", name,
-		"--apiexport-ref", apiExport,
+		refFlag, refValue,
 		"--enable-leader-election=false",
 		"--kubeconfig", localKubeconfig,
 		"--kcp-kubeconfig", kcpKubeconfig,

--- a/test/utils/utils.go
+++ b/test/utils/utils.go
@@ -21,6 +21,7 @@ import (
 	"net/url"
 	"os"
 	"regexp"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -204,4 +205,23 @@ func YAMLToUnstructured(t *testing.T, data string) *unstructured.Unstructured {
 	}
 
 	return ToUnstructured(t, obj)
+}
+
+func KCPMinor() int {
+	version := os.Getenv("KCP_VERSION")
+	if version == "" {
+		panic("No $KCP_VERSION environment variable defined.")
+	}
+
+	parts := strings.SplitN(version, ".", 3)
+	if len(parts) != 3 {
+		panic("Invalid $KCP_VERSION, must be X.Y.Z.")
+	}
+
+	minor, err := strconv.ParseInt(parts[1], 10, 32)
+	if err != nil {
+		panic(fmt.Sprintf("Invalid $KCP_VERSION: not parseable: %v", err))
+	}
+
+	return int(minor)
 }


### PR DESCRIPTION
## Summary
This implements support for APIExportEndpointSlices (AEES).

Starting with kcp 0.28, APIExports do not contain the virtual workspace URLs anymore (unless you specify a feature flag on kcp, and we certainly do not want to make that required for running the Agent). Instead in 0.28+, kcp will automatically create an AEES for each new APIExport, using the same name as the export.

In kcp 0.27, admins *can* manually create an AEES for their APIExport, but are not forced to because kcp still makes the URLs available in the APIExport.

To handle each and every situation, the agent now simply supports both scenarios. You can run it like before with `--apiexport-ref` if you're still on 0.27, or you can use `--apiexportendpointslice-ref` when you are in kcp 0.28+ or you make use of custom AEES in 0.27 already. The agent's `main` function will simply resolve the flags as before and figure it all out, so the main meat part of the agent can remain unchanged.

## What Type of PR Is This?
/kind feature

## Related Issue(s)
Fixes #86

## Release Notes
```release-note
* Support kcp 0.28.
* Support configuring an APIExportEndpointSlice instead of an APIExport using command line flags.
```
