### PR TITLE
fix templating variables for related resources

### DIFF
--- a/internal/sync/syncer_related.go
+++ b/internal/sync/syncer_related.go
@@ -599,10 +599,10 @@ func templateLabelSelector(relatedOrigin, relatedDest syncSide, origin syncagent
 
 func remapSyncSides(relatedOrigin, relatedDest syncSide, origin syncagentv1alpha1.RelatedResourceOrigin) (localSide, remoteSide syncSide) {
 	if origin == syncagentv1alpha1.RelatedResourceOriginKcp {
-		return relatedOrigin, relatedDest
+		return relatedDest, relatedOrigin
 	}
 
-	return relatedDest, relatedOrigin
+	return relatedOrigin, relatedDest
 }
 
 func oppositeSide(origin syncagentv1alpha1.RelatedResourceOrigin) syncagentv1alpha1.RelatedResourceOrigin {


### PR DESCRIPTION
## Summary
I made a simple mistake when writing this function and never caught it because none of the tests checked that side-related information (i.e. the cluster name or the workspace path) are actually available.

Since the cluster name is dynamic, the best I could come up with is relying on its length, which we always know :)

## What Type of PR Is This?
/kind bug

## Related Issue(s)
Fixes #90

## Release Notes
```release-note
Fix `ClusterName` and `WorkspacePath` being empty in templating strings for related resources.
```
