### PR TITLE
Fix support for workspace paths

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -106,7 +106,7 @@ $(YQ):
 	  yq_*
 
 KCP = _tools/kcp
-KCP_VERSION ?= 0.28.1
+export KCP_VERSION ?= 0.28.1
 
 .PHONY: $(KCP)
 $(KCP):

--- a/internal/controller/syncmanager/controller.go
+++ b/internal/controller/syncmanager/controller.go
@@ -29,6 +29,7 @@ import (
 	syncagentv1alpha1 "github.com/kcp-dev/api-syncagent/sdk/apis/syncagent/v1alpha1"
 
 	kcpapisv1alpha1 "github.com/kcp-dev/kcp/sdk/apis/apis/v1alpha1"
+	kcpcorev1alpha1 "github.com/kcp-dev/kcp/sdk/apis/core/v1alpha1"
 	apiexportprovider "github.com/kcp-dev/multicluster-provider/apiexport"
 	mccontroller "sigs.k8s.io/multicluster-runtime/pkg/controller"
 	mcmanager "sigs.k8s.io/multicluster-runtime/pkg/manager"
@@ -246,6 +247,10 @@ func (r *Reconciler) ensureManager(log *zap.SugaredLogger, vwURL string) error {
 
 	if err := kcpapisv1alpha1.AddToScheme(scheme); err != nil {
 		return fmt.Errorf("failed to register scheme %s: %w", kcpapisv1alpha1.SchemeGroupVersion, err)
+	}
+
+	if err := kcpcorev1alpha1.AddToScheme(scheme); err != nil {
+		return fmt.Errorf("failed to register scheme %s: %w", kcpcorev1alpha1.SchemeGroupVersion, err)
 	}
 
 	if r.vwProvider == nil {

--- a/test/e2e/sync/primary_test.go
+++ b/test/e2e/sync/primary_test.go
@@ -739,3 +739,103 @@ spec:
 		t.Fatalf("Failed to wait for object to be synced down: %v", err)
 	}
 }
+
+func TestSyncWithWorkspacePath(t *testing.T) {
+	const (
+		apiExportName = "kcp.example.com"
+		kcpGroupName  = "kcp.example.com"
+		orgWorkspace  = "sync-with-paths"
+	)
+
+	ctx := t.Context()
+	ctrlruntime.SetLogger(logr.Discard())
+
+	// setup a test environment in kcp
+	orgKubconfig := utils.CreateOrganization(t, ctx, orgWorkspace, apiExportName)
+
+	// start a service cluster
+	envtestKubeconfig, envtestClient, _ := utils.RunEnvtest(t, []string{
+		"test/crds/crontab.yaml",
+	})
+
+	// publish Crontabs and Backups
+	t.Logf("Publishing CRDs…")
+	prCrontabs := &syncagentv1alpha1.PublishedResource{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "publish-crontabs",
+		},
+		Spec: syncagentv1alpha1.PublishedResourceSpec{
+			Resource: syncagentv1alpha1.SourceResourceDescriptor{
+				APIGroup: "example.com",
+				Version:  "v1",
+				Kind:     "CronTab",
+			},
+			// These rules make finding the local object easier, but should not be used in production.
+			Naming: &syncagentv1alpha1.ResourceNaming{
+				Name:      "{{ .Object.metadata.name }}",
+				Namespace: "synced-{{ .Object.metadata.namespace }}",
+			},
+			Projection: &syncagentv1alpha1.ResourceProjection{
+				Group: kcpGroupName,
+			},
+			EnableWorkspacePaths: true,
+		},
+	}
+
+	if err := envtestClient.Create(ctx, prCrontabs); err != nil {
+		t.Fatalf("Failed to create PublishedResource: %v", err)
+	}
+
+	// start the agent in the background to update the APIExport with the CronTabs API
+	utils.RunAgent(ctx, t, "bob", orgKubconfig, envtestKubeconfig, apiExportName)
+
+	// wait until the API is available
+	kcpClusterClient := utils.GetKcpAdminClusterClient(t)
+
+	teamClusterPath := logicalcluster.NewPath("root").Join(orgWorkspace).Join("team-1")
+	teamClient := kcpClusterClient.Cluster(teamClusterPath)
+
+	utils.WaitForBoundAPI(t, ctx, teamClient, schema.GroupVersionResource{
+		Group:    kcpGroupName,
+		Version:  "v1",
+		Resource: "crontabs",
+	})
+
+	// create a Crontab object in a team workspace
+	t.Log("Creating CronTab in kcp…")
+	crontab := utils.YAMLToUnstructured(t, `
+apiVersion: kcp.example.com/v1
+kind: CronTab
+metadata:
+  namespace: default
+  name: my-crontab
+spec:
+  cronSpec: '* * *'
+  image: ubuntu:latest
+`)
+
+	if err := teamClient.Create(ctx, crontab); err != nil {
+		t.Fatalf("Failed to create CronTab in kcp: %v", err)
+	}
+
+	// wait for the agent to sync the object down into the service cluster
+
+	t.Logf("Wait for CronTab to be synced…")
+	copy := &unstructured.Unstructured{}
+	copy.SetAPIVersion("example.com/v1")
+	copy.SetKind("CronTab")
+
+	err := wait.PollUntilContextTimeout(ctx, 500*time.Millisecond, 30*time.Second, false, func(ctx context.Context) (done bool, err error) {
+		copyKey := types.NamespacedName{Namespace: "synced-default", Name: "my-crontab"}
+		return envtestClient.Get(ctx, copyKey, copy) == nil, nil
+	})
+	if err != nil {
+		t.Fatalf("Failed to wait for object to be synced down: %v", err)
+	}
+
+	ann := "syncagent.kcp.io/remote-object-workspace-path"
+
+	if value := copy.GetAnnotations()[ann]; value != teamClusterPath.String() {
+		t.Fatalf("Expected %s annotation to be %q, but is %q.", ann, teamClusterPath.String(), value)
+	}
+}

--- a/test/utils/fixtures.go
+++ b/test/utils/fixtures.go
@@ -287,6 +287,16 @@ func BindToAPIExport(t *testing.T, ctx context.Context, client ctrlruntimeclient
 					},
 					State: kcpapisv1alpha1.ClaimAccepted,
 				},
+				{
+					PermissionClaim: kcpapisv1alpha1.PermissionClaim{
+						GroupResource: kcpapisv1alpha1.GroupResource{
+							Group:    "core.kcp.io",
+							Resource: "logicalclusters",
+						},
+						All: true,
+					},
+					State: kcpapisv1alpha1.ClaimAccepted,
+				},
 			},
 		},
 	}


### PR DESCRIPTION
## Summary
PublishedResources have a flag to enable fetching the logicalcluster and determining the workspace path of a remote object. However enabling this flag didn't actually work because

* logicalclusters were not claimed in the APIExport
* core.kcp.io/v1alpha1 was not added to the client's scheme

This PR rectifies both problems and adds a basic testcase to ensure it works.

## What Type of PR Is This?
/kind bug

## Release Notes
```release-note
Fix `EnableWorkspacePaths` in PublishedResources not having any visible effect, fix missing permission claim for logicalclusters.
```
