### PR TITLE
use strings instead of custom types when passing to templating

### DIFF
--- a/internal/sync/templating/naming.go
+++ b/internal/sync/templating/naming.go
@@ -35,16 +35,16 @@ type localObjectNamingContext struct {
 	// Object is the full remote object found in a kcp workspace.
 	Object map[string]any
 	// ClusterName is the internal cluster identifier (e.g. "34hg2j4gh24jdfgf").
-	ClusterName logicalcluster.Name
+	ClusterName string
 	// ClusterPath is the workspace path (e.g. "root:customer:projectx").
-	ClusterPath logicalcluster.Path
+	ClusterPath string
 }
 
 func newLocalObjectNamingContext(object *unstructured.Unstructured, clusterName logicalcluster.Name, workspacePath logicalcluster.Path) localObjectNamingContext {
 	return localObjectNamingContext{
 		Object:      object.Object,
-		ClusterName: clusterName,
-		ClusterPath: workspacePath,
+		ClusterName: clusterName.String(),
+		ClusterPath: workspacePath.String(),
 	}
 }
 

--- a/internal/sync/templating/related.go
+++ b/internal/sync/templating/related.go
@@ -38,18 +38,18 @@ type relatedObjectContext struct {
 	// ClusterName is the internal cluster identifier (e.g. "34hg2j4gh24jdfgf")
 	// of the kcp workspace that the synchronization is currently processing. This
 	// value is set for both evaluations, regardless of side.
-	ClusterName logicalcluster.Name
+	ClusterName string
 	// ClusterPath is the workspace path (e.g. "root:customer:projectx"). This
 	// value is set for both evaluations, regardless of side.
-	ClusterPath logicalcluster.Path
+	ClusterPath string
 }
 
 func NewRelatedObjectContext(object *unstructured.Unstructured, side syncagentv1alpha1.RelatedResourceOrigin, clusterName logicalcluster.Name, clusterPath logicalcluster.Path) relatedObjectContext {
 	return relatedObjectContext{
 		Side:        side,
 		Object:      object.Object,
-		ClusterName: clusterName,
-		ClusterPath: clusterPath,
+		ClusterName: clusterName.String(),
+		ClusterPath: clusterPath.String(),
 	}
 }
 
@@ -64,17 +64,17 @@ type relatedObjectLabelContext struct {
 	// ClusterName is the internal cluster identifier (e.g. "34hg2j4gh24jdfgf")
 	// of the kcp workspace that the synchronization is currently processing
 	// (where the remote object exists).
-	ClusterName logicalcluster.Name
+	ClusterName string
 	// ClusterPath is the workspace path (e.g. "root:customer:projectx").
-	ClusterPath logicalcluster.Path
+	ClusterPath string
 }
 
 func NewRelatedObjectLabelContext(localObject, remoteObject *unstructured.Unstructured, clusterName logicalcluster.Name, clusterPath logicalcluster.Path) relatedObjectLabelContext {
 	return relatedObjectLabelContext{
 		LocalObject:  localObject.Object,
 		RemoteObject: remoteObject.Object,
-		ClusterName:  clusterName,
-		ClusterPath:  clusterPath,
+		ClusterName:  clusterName.String(),
+		ClusterPath:  clusterPath.String(),
 	}
 }
 
@@ -103,9 +103,9 @@ type relatedObjectLabelRewriteContext struct {
 	// ClusterName is the internal cluster identifier (e.g. "34hg2j4gh24jdfgf")
 	// of the kcp workspace that the synchronization is currently processing
 	// (where the remote object exists).
-	ClusterName logicalcluster.Name
+	ClusterName string
 	// ClusterPath is the workspace path (e.g. "root:customer:projectx").
-	ClusterPath logicalcluster.Path
+	ClusterPath string
 }
 
 func NewRelatedObjectLabelRewriteContext(value string, localObject, remoteObject, relatedObject *unstructured.Unstructured, clusterName logicalcluster.Name, clusterPath logicalcluster.Path) relatedObjectLabelRewriteContext {
@@ -113,8 +113,8 @@ func NewRelatedObjectLabelRewriteContext(value string, localObject, remoteObject
 		Value:        value,
 		LocalObject:  localObject.Object,
 		RemoteObject: remoteObject.Object,
-		ClusterName:  clusterName,
-		ClusterPath:  clusterPath,
+		ClusterName:  clusterName.String(),
+		ClusterPath:  clusterPath.String(),
 	}
 
 	if relatedObject != nil {


### PR DESCRIPTION
This is required since functions like sha3 short expect a string to work properly and not the custom type

<!--

Thanks for creating a pull request!
If this is your first time, please make sure to review CONTRIBUTING.MD.

-->

## Summary

## What Type of PR Is This?

<!--

Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->
/kind bug

## Related Issue(s)

Fixes #

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
Fix: ClusterName and ClusterPath can now be used in conjunction with sha3short template function 
```
