### PR TITLE
Pass a logger to unmanaged sync controller to surface reconcile errors

### DIFF
--- a/internal/controller/sync/controller.go
+++ b/internal/controller/sync/controller.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/go-logr/zapr"
 	"github.com/kcp-dev/logicalcluster/v3"
 	"go.uber.org/zap"
 
@@ -125,6 +126,7 @@ func Create(
 		Reconciler:              reconciler,
 		MaxConcurrentReconciles: numWorkers,
 		SkipNameValidation:      ptr.To(true),
+		Logger:                  zapr.NewLogger(log.Desugar()),
 	}
 
 	log.Info("Setting up unmanaged controller...")


### PR DESCRIPTION
<!--

Thanks for creating a pull request!
If this is your first time, please make sure to review CONTRIBUTING.MD.

-->

## Summary

It looks like an unmanaged controller (in controller-rutime? or multicluster-runtime?) doesn't log its reconciler errors unless you pass a logger into it. Thus, tons of errors are swallowed without any indication why.

## What Type of PR Is This?

/kind bug

## Related Issue(s)

Fixes #

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
Correctly log reconciler errors for object sync
```
