### PR TITLE
Update to Go 1.24.8

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
       - .goreleaser.yaml
   push:
     tags:
-      - 'v*'
+      - "v*"
 
 permissions:
   contents: read
@@ -27,7 +27,7 @@ jobs:
 
       - uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # tag=v5.4.0
         with:
-          go-version: v1.24.3
+          go-version: v1.24.8
           cache: true
 
       - name: Delete non-semver tags
@@ -41,7 +41,7 @@ jobs:
         uses: goreleaser/goreleaser-action@9c156ee8a17a598857849441385a2041ef570552 # tag=v6.3.0
         with:
           distribution: goreleaser
-          version: '~> v2'
+          version: "~> v2"
           args: release --timeout 60m
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -51,7 +51,7 @@ jobs:
         uses: goreleaser/goreleaser-action@9c156ee8a17a598857849441385a2041ef570552 # tag=v6.3.0
         with:
           distribution: goreleaser
-          version: '~> v2'
+          version: "~> v2"
           args: release --timeout 60m --snapshot
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.prow.yaml
+++ b/.prow.yaml
@@ -21,7 +21,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: ghcr.io/kcp-dev/infra/build:1.24.3-1
+        - image: ghcr.io/kcp-dev/infra/build:1.24.8-1
           command:
             - hack/ci/verify.sh
           resources:
@@ -37,7 +37,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: ghcr.io/kcp-dev/infra/build:1.24.3-1
+        - image: ghcr.io/kcp-dev/infra/build:1.24.8-1
           command:
             - make
             - lint
@@ -59,7 +59,7 @@ presubmits:
             - hack/ci/build-image.sh
           env:
             - name: DRY_RUN
-              value: '1'
+              value: "1"
           # docker-in-docker needs privileged mode
           securityContext:
             privileged: true
@@ -76,13 +76,13 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: ghcr.io/kcp-dev/infra/build:1.24.3-1
+        - image: ghcr.io/kcp-dev/infra/build:1.24.8-1
           command:
             - make
             - test
           env:
             - name: USE_GOTESTSUM
-              value: '1'
+              value: "1"
           resources:
             requests:
               memory: 4Gi
@@ -96,12 +96,12 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: ghcr.io/kcp-dev/infra/build:1.24.3-1
+        - image: ghcr.io/kcp-dev/infra/build:1.24.8-1
           command:
             - hack/ci/run-e2e-tests.sh
           env:
             - name: KCP_VERSION
-              value: '0.27.1'
+              value: "0.27.1"
           resources:
             requests:
               memory: 4Gi
@@ -115,12 +115,12 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: ghcr.io/kcp-dev/infra/build:1.24.3-1
+        - image: ghcr.io/kcp-dev/infra/build:1.24.8-1
           command:
             - hack/ci/run-e2e-tests.sh
           env:
             - name: KCP_VERSION
-              value: '0.28.1'
+              value: "0.28.1"
           resources:
             requests:
               memory: 4Gi

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM --platform=${BUILDPLATFORM} docker.io/golang:1.24.3 AS builder
+FROM --platform=${BUILDPLATFORM} docker.io/golang:1.24.8 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 


### PR DESCRIPTION
<!--

Thanks for creating a pull request!
If this is your first time, please make sure to review CONTRIBUTING.MD.

-->

## Summary

Updates our Go version to the latest 1.24 release.

## What Type of PR Is This?

/kind cleanup

## Related Issue(s)

Towards https://github.com/kcp-dev/infra/issues/136

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
api-syncagent is built with Go 1.24.8
```
