### PR TITLE
Update to Go 1.24.9

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
 
       - uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # tag=v5.4.0
         with:
-          go-version: v1.24.8
+          go-version: v1.24.9
           cache: true
 
       - name: Delete non-semver tags

--- a/.prow.yaml
+++ b/.prow.yaml
@@ -21,7 +21,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: ghcr.io/kcp-dev/infra/build:1.24.8-1
+        - image: ghcr.io/kcp-dev/infra/build:1.24.9-1
           command:
             - hack/ci/verify.sh
           resources:
@@ -37,7 +37,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: ghcr.io/kcp-dev/infra/build:1.24.8-1
+        - image: ghcr.io/kcp-dev/infra/build:1.24.9-1
           command:
             - make
             - lint
@@ -76,7 +76,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: ghcr.io/kcp-dev/infra/build:1.24.8-1
+        - image: ghcr.io/kcp-dev/infra/build:1.24.9-1
           command:
             - make
             - test
@@ -96,7 +96,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: ghcr.io/kcp-dev/infra/build:1.24.8-1
+        - image: ghcr.io/kcp-dev/infra/build:1.24.9-1
           command:
             - hack/ci/run-e2e-tests.sh
           env:
@@ -115,7 +115,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: ghcr.io/kcp-dev/infra/build:1.24.8-1
+        - image: ghcr.io/kcp-dev/infra/build:1.24.9-1
           command:
             - hack/ci/run-e2e-tests.sh
           env:

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM --platform=${BUILDPLATFORM} docker.io/golang:1.24.8 AS builder
+FROM --platform=${BUILDPLATFORM} docker.io/golang:1.24.9 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 


### PR DESCRIPTION
<!--

Thanks for creating a pull request!
If this is your first time, please make sure to review CONTRIBUTING.MD.

-->

## Summary

Follow-up to #106 because Go 1.24.8 has a X509 certificate parsing regression.

## What Type of PR Is This?

/kind cleanup

## Related Issue(s)

Towards https://github.com/kcp-dev/infra/issues/136

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
api-syncagent is built with Go 1.24.9
```
