### PR TITLE
Fix APIResourceSchema agent annotations/labels

### DIFF
--- a/internal/controller/apiresourceschema/controller.go
+++ b/internal/controller/apiresourceschema/controller.go
@@ -164,7 +164,8 @@ func (r *Reconciler) reconcile(ctx context.Context, log *zap.SugaredLogger, pubR
 	ars := &kcpapisv1alpha1.APIResourceSchema{}
 	err = r.kcpClient.Get(ctx, types.NamespacedName{Name: arsName}, ars, &ctrlruntimeclient.GetOptions{})
 
-	if apierrors.IsNotFound(err) {
+	switch {
+	case apierrors.IsNotFound(err):
 		ars, err := kcp.CreateAPIResourceSchema(projectedCRD, arsName, r.agentName)
 		if err != nil {
 			return nil, fmt.Errorf("failed to construct APIResourceSchema: %w", err)
@@ -175,8 +176,40 @@ func (r *Reconciler) reconcile(ctx context.Context, log *zap.SugaredLogger, pubR
 		if err := r.kcpClient.Create(ctx, ars); err != nil {
 			return nil, fmt.Errorf("failed to create APIResourceSchema: %w", err)
 		}
-	} else if err != nil {
+
+	case err != nil:
 		return nil, fmt.Errorf("failed to check for APIResourceSchema: %w", err)
+
+	default:
+		// A bug in earlier api-syncagent versions made any agent potentially reconcile any PublishedResource,
+		// ignoring the configured PR filter. This would lead to the wrong agent name in the ARS labels
+		// and annotations.
+		// ARS are immutable and normally we would never need to update the metadata on one, we do it
+		// temporarily anyway to fix broken metadata. The metadata is of informational nature only,
+		// so having the wrong values is just a cosmetic issue.
+		//
+		// TODO: Remove this at some point when we're sure enough all ARS out there have been fixed.
+
+		validAnnotation := ars.Annotations[syncagentv1alpha1.AgentNameAnnotation] == r.agentName
+		validLabel := ars.Labels[syncagentv1alpha1.AgentNameLabel] == r.agentName
+
+		if !validAnnotation || !validLabel {
+			if ars.Labels == nil {
+				ars.Labels = map[string]string{}
+			}
+			if ars.Annotations == nil {
+				ars.Annotations = map[string]string{}
+			}
+
+			ars.Labels[syncagentv1alpha1.AgentNameLabel] = r.agentName
+			ars.Annotations[syncagentv1alpha1.AgentNameAnnotation] = r.agentName
+
+			log.With("name", arsName).Info("Fixing incorrect agent metadata…")
+
+			if err := r.kcpClient.Update(ctx, ars); err != nil {
+				return nil, fmt.Errorf("failed to update APIResourceSchema: %w", err)
+			}
+		}
 	}
 
 	// update Status with ARS name


### PR DESCRIPTION
## Summary
The controller responsible for creating APIResourceSchemas (ARS) was using the PublishedResource (PR) filter only for filtering PRs immediately, but when determining the list of PRs for a given ARS, it forgot to take the filter into account.

This meant that every agent was racing to create the ARS in kcp. As long as no projections are configured (or they are configured identically), this would be a harmless race as all agents settle on the same ARS.

This PR fixes the problem and also adds some extra logic to fix existing ARS. Normally ARS are never updated (their entire spec is immutable), but metadata can be changed and it's an easy fix and nice to have.

## What Type of PR Is This?
/kind bug

## Release Notes
```release-note
Fix agent not applying the PublishedResources filter when creating APIResourceSchemas, which could lead to wrong agent label/annotations on those created schemas.
```
