### PR TITLE
update to Go 1.26.2

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -8,7 +8,7 @@ If this is your first time, please make sure to review CONTRIBUTING.md.
 ## Summary
 <!--
 Please provide a description that explains *why* your PR is changing something
-in the codebase, and focus less on what *what* you're changing. The following are
+in the codebase, and focus less on *what* you're changing. The following are
 good questions to ask yourself when writing the PR summary:
 
 * What are the problems you are trying to solve?

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,18 +1,26 @@
 <!--
 
 Thanks for creating a pull request!
-If this is your first time, please make sure to review CONTRIBUTING.MD.
+If this is your first time, please make sure to review CONTRIBUTING.md.
 
 -->
 
 ## Summary
+<!--
+Please provide a description that explains *why* your PR is changing something
+in the codebase, and focus less on what *what* you're changing. The following are
+good questions to ask yourself when writing the PR summary:
+
+* What are the problems you are trying to solve?
+* What assumptions did you make when implementing your changes?
+* Which workflows will be affected/improved by your change?
+-->
 
 ## What Type of PR Is This?
-
 <!--
-
 Add one of the following kinds:
 /kind bug
+/kind chore
 /kind cleanup
 /kind documentation
 /kind feature
@@ -23,19 +31,16 @@ Optionally add one or more of the following kinds if applicable:
 /kind failing-test
 /kind flake
 /kind regression
-
 -->
 
 ## Related Issue(s)
-
 Fixes #
 
 ## Release Notes
-
 <!--
-Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
+Please add a release note in the block below.
+Leave NONE only if no user-facing changes are in this PR.
 -->
-
 ```release-note
 NONE
 ```

--- a/.github/workflows/docs-gen-and-push.yaml
+++ b/.github/workflows/docs-gen-and-push.yaml
@@ -36,7 +36,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # tag=v6.1.0
         with:
-          go-version: v1.25.7
+          go-version: v1.26.2
           cache: true
 
       - uses: actions/setup-python@83679a892e2d95755f2dac6acb0bfd1e9ac5d548 #tag=v6.1.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # tag=v6.1.0
         with:
-          go-version: v1.24.11
+          go-version: v1.26.2
           cache: true
 
       - name: Delete non-semver tags

--- a/.prow.yaml
+++ b/.prow.yaml
@@ -21,7 +21,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: ghcr.io/kcp-dev/infra/build:1.25.7-1
+        - image: ghcr.io/kcp-dev/infra/build:1.26.2-1
           command:
             - hack/ci/verify.sh
           resources:
@@ -37,7 +37,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: ghcr.io/kcp-dev/infra/build:1.25.7-1
+        - image: ghcr.io/kcp-dev/infra/build:1.26.2-1
           command:
             - make
             - lint
@@ -76,7 +76,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: ghcr.io/kcp-dev/infra/build:1.25.7-1
+        - image: ghcr.io/kcp-dev/infra/build:1.26.2-1
           command:
             - make
             - test
@@ -96,7 +96,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: ghcr.io/kcp-dev/infra/build:1.25.7-1
+        - image: ghcr.io/kcp-dev/infra/build:1.26.2-1
           command:
             - hack/ci/run-e2e-tests.sh
           env:
@@ -115,7 +115,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: ghcr.io/kcp-dev/infra/build:1.25.7-1
+        - image: ghcr.io/kcp-dev/infra/build:1.26.2-1
           command:
             - hack/ci/run-e2e-tests.sh
           env:
@@ -134,7 +134,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: ghcr.io/kcp-dev/infra/build:1.25.7-1
+        - image: ghcr.io/kcp-dev/infra/build:1.26.2-1
           command:
             - hack/ci/run-e2e-tests.sh
           env:

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM --platform=${BUILDPLATFORM} docker.io/golang:1.25.7 AS builder
+FROM --platform=${BUILDPLATFORM} docker.io/golang:1.26.2 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kcp-dev/api-syncagent
 
-go 1.25.7
+go 1.25.0
 
 replace github.com/kcp-dev/api-syncagent/sdk => ./sdk
 


### PR DESCRIPTION
## Summary
This bumps us to the latest Go version, including many security fixes.

I also included the updated PR template from the kcp operator, giving friendly hints at AI agents to focus less on repetitive noise.

## What Type of PR Is This?
/kind chore

## Release Notes
```release-note
Update to Go 1.26.2.
```
