### PR TITLE
remove e2e tests for kcp <0.29, add tests for kcp >0.29

### DIFF
--- a/.prow.yaml
+++ b/.prow.yaml
@@ -88,44 +88,6 @@ presubmits:
               memory: 4Gi
               cpu: 2
 
-  - name: pull-api-syncagent-test-e2e-kcp-0.27
-    always_run: true
-    decorate: true
-    clone_uri: "https://github.com/kcp-dev/api-syncagent"
-    labels:
-      preset-goproxy: "true"
-    spec:
-      containers:
-        - image: ghcr.io/kcp-dev/infra/build:1.26.2-1
-          command:
-            - hack/ci/run-e2e-tests.sh
-          env:
-            - name: KCP_VERSION
-              value: "0.27.1"
-          resources:
-            requests:
-              memory: 4Gi
-              cpu: 2
-
-  - name: pull-api-syncagent-test-e2e-kcp-0.28
-    always_run: true
-    decorate: true
-    clone_uri: "https://github.com/kcp-dev/api-syncagent"
-    labels:
-      preset-goproxy: "true"
-    spec:
-      containers:
-        - image: ghcr.io/kcp-dev/infra/build:1.26.2-1
-          command:
-            - hack/ci/run-e2e-tests.sh
-          env:
-            - name: KCP_VERSION
-              value: "0.28.1"
-          resources:
-            requests:
-              memory: 4Gi
-              cpu: 2
-
   - name: pull-api-syncagent-test-e2e-kcp-0.29
     always_run: true
     decorate: true
@@ -139,7 +101,45 @@ presubmits:
             - hack/ci/run-e2e-tests.sh
           env:
             - name: KCP_VERSION
-              value: "0.29.0"
+              value: "0.29.3"
+          resources:
+            requests:
+              memory: 4Gi
+              cpu: 2
+
+  - name: pull-api-syncagent-test-e2e-kcp-0.30
+    always_run: true
+    decorate: true
+    clone_uri: "https://github.com/kcp-dev/api-syncagent"
+    labels:
+      preset-goproxy: "true"
+    spec:
+      containers:
+        - image: ghcr.io/kcp-dev/infra/build:1.26.2-1
+          command:
+            - hack/ci/run-e2e-tests.sh
+          env:
+            - name: KCP_VERSION
+              value: "0.30.3"
+          resources:
+            requests:
+              memory: 4Gi
+              cpu: 2
+
+  - name: pull-api-syncagent-test-e2e-kcp-0.31
+    always_run: true
+    decorate: true
+    clone_uri: "https://github.com/kcp-dev/api-syncagent"
+    labels:
+      preset-goproxy: "true"
+    spec:
+      containers:
+        - image: ghcr.io/kcp-dev/infra/build:1.26.2-1
+          command:
+            - hack/ci/run-e2e-tests.sh
+          env:
+            - name: KCP_VERSION
+              value: "0.31.0"
           resources:
             requests:
               memory: 4Gi


### PR DESCRIPTION
## Summary
This removes tests for kcp releases that are not officially supported anymore, and adds tests for supported releases.

## What Type of PR Is This?
/kind chore

## Release Notes
```release-note
NONE
```
