### PR TITLE
Allow to delete related object copies when the primary object is deleted

### DIFF
--- a/deploy/crd/kcp.io/syncagent.kcp.io_publishedresources.yaml
+++ b/deploy/crd/kcp.io/syncagent.kcp.io_publishedresources.yaml
@@ -381,6 +381,13 @@ spec:
                       (in the following rule, group is optional becaue core/v1 is represented by group="")
                       group is included here because when an identityHash is used, core/v1 cannot possible be targetted
                     properties:
+                      cleanup:
+                        description: |-
+                          Cleanup can be set to true to make the syncagent delete any copy of this related resource on
+                          the destination side (i.e. the original related object will not be touched, regardless of this
+                          option). Leaving this disabled, the syncagent will only create copies of the related objects,
+                          but never delete them itself.
+                        type: boolean
                       group:
                         description: |-
                           Group is the API group of the related resource. This should be left blank for resources

--- a/internal/controller/sync/controller.go
+++ b/internal/controller/sync/controller.go
@@ -194,11 +194,8 @@ func setupRelatedResourceWatches(
 			continue
 		}
 
-		gvr := schema.GroupVersionResource{
-			Group:    relRes.Group,
-			Version:  relRes.Version,
-			Resource: relRes.Resource,
-		}
+		// this handles the legacy .Kind-based related resources
+		gvr := projection.RelatedResourceGVR(&relRes)
 
 		// Use the REST mapper of the origin side: related resources may have projected GVKs
 		// that differ between kcp and the service cluster, so we must resolve using the

--- a/internal/sync/syncer_related.go
+++ b/internal/sync/syncer_related.go
@@ -127,6 +127,12 @@ func (s *ResourceSyncer) processRelatedResource(ctx context.Context, log *zap.Su
 			object:      destObject,
 		}
 
+		// We "forward" the deletion to the related objects only if the primary is already in deletion
+		// and the related object either originated from the user (so on the service cluster we just
+		// have a useless copy once the main object has been cleared up) OR the admin explicitly opted
+		// into the cleanup procedure to ensure that copies of the related object are removed.
+		forceDelete := primaryDeleting && (relRes.Cleanup || relRes.Origin == syncagentv1alpha1.RelatedResourceOriginKcp)
+
 		syncer := objectSyncer{
 			// Related objects within kcp are not labelled with the agent name because it's unnecessary.
 			// agentName: "",
@@ -155,8 +161,10 @@ func (s *ResourceSyncer) processRelatedResource(ctx context.Context, log *zap.Su
 			// feature at all.
 			syncStatusBack: false,
 			// if the origin is on the remote side, we want to add a finalizer to make
-			// sure we can clean up properly
-			blockSourceDeletion: relRes.Origin == "kcp",
+			// sure we can clean up properly; when forceDelete is enabled, we are in deletion mode and
+			// want to force the deletion, so we ignore the related object's origin (it was taken into
+			// account when defining forceDelete).
+			blockSourceDeletion: forceDelete || relRes.Origin == syncagentv1alpha1.RelatedResourceOriginKcp,
 			// apply mutation rules configured for the related resource
 			mutator: s.relatedMutators[relRes.Identifier],
 			// we never want to store sync-related metadata inside kcp
@@ -164,8 +172,7 @@ func (s *ResourceSyncer) processRelatedResource(ctx context.Context, log *zap.Su
 			// events are always created on the kcp side
 			eventObjSide: eventObjSide,
 			// force deletion of related resources when the primary object is being deleted
-			// (only for origin:kcp resources that have blockSourceDeletion)
-			forceDelete: primaryDeleting && relRes.Origin == syncagentv1alpha1.RelatedResourceOriginKcp,
+			forceDelete: forceDelete,
 		}
 
 		req, err := syncer.Sync(ctx, log, sourceSide, destSide)

--- a/sdk/apis/syncagent/v1alpha1/published_resource.go
+++ b/sdk/apis/syncagent/v1alpha1/published_resource.go
@@ -243,6 +243,12 @@ type RelatedResourceSpec struct {
 	// provided by an APIExport and not Kube-native.
 	IdentityHash string `json:"identityHash,omitempty"`
 
+	// Cleanup can be set to true to make the syncagent delete any copy of this related resource on
+	// the destination side (i.e. the original related object will not be touched, regardless of this
+	// option). Leaving this disabled, the syncagent will only create copies of the related objects,
+	// but never delete them itself.
+	Cleanup bool `json:"cleanup,omitempty"`
+
 	// Projection is used to change the GVK of a related resource on the opposite side of
 	// its origin.
 	// All fields in the projection are optional. If a field is set, it will overwrite

--- a/sdk/applyconfiguration/syncagent/v1alpha1/relatedresourcespec.go
+++ b/sdk/applyconfiguration/syncagent/v1alpha1/relatedresourcespec.go
@@ -32,6 +32,7 @@ type RelatedResourceSpecApplyConfiguration struct {
 	Resource     *string                                      `json:"resource,omitempty"`
 	Kind         *string                                      `json:"kind,omitempty"`
 	IdentityHash *string                                      `json:"identityHash,omitempty"`
+	Cleanup      *bool                                        `json:"cleanup,omitempty"`
 	Projection   *RelatedResourceProjectionApplyConfiguration `json:"projection,omitempty"`
 	Object       *RelatedResourceObjectApplyConfiguration     `json:"object,omitempty"`
 	Mutation     *ResourceMutationSpecApplyConfiguration      `json:"mutation,omitempty"`
@@ -97,6 +98,14 @@ func (b *RelatedResourceSpecApplyConfiguration) WithKind(value string) *RelatedR
 // If called multiple times, the IdentityHash field is set to the value of the last call.
 func (b *RelatedResourceSpecApplyConfiguration) WithIdentityHash(value string) *RelatedResourceSpecApplyConfiguration {
 	b.IdentityHash = &value
+	return b
+}
+
+// WithCleanup sets the Cleanup field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the Cleanup field is set to the value of the last call.
+func (b *RelatedResourceSpecApplyConfiguration) WithCleanup(value bool) *RelatedResourceSpecApplyConfiguration {
+	b.Cleanup = &value
 	return b
 }
 

--- a/test/e2e/sync/cleanup_test.go
+++ b/test/e2e/sync/cleanup_test.go
@@ -1,0 +1,416 @@
+//go:build e2e
+
+/*
+Copyright 2025 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sync
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/go-logr/logr"
+
+	syncagentv1alpha1 "github.com/kcp-dev/api-syncagent/sdk/apis/syncagent/v1alpha1"
+	"github.com/kcp-dev/api-syncagent/test/utils"
+
+	"github.com/kcp-dev/logicalcluster/v3"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
+	ctrlruntime "sigs.k8s.io/controller-runtime"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// TestRelatedResourceCleanupDisabled verifies that when a primary object
+// is deleted, related resources are NOT automatically deleted by default.
+func TestRelatedResourceCleanupDisabled(t *testing.T) {
+	const (
+		apiExportName = "kcp.example.com"
+		orgWorkspace  = "cleanup-disabled"
+	)
+
+	ctx := t.Context()
+	ctrlruntime.SetLogger(logr.Discard())
+
+	// setup a test environment in kcp
+	orgKubconfig := utils.CreateOrganization(t, ctx, orgWorkspace, apiExportName)
+
+	// start a service cluster
+	envtestKubeconfig, envtestClient, _ := utils.RunEnvtest(t, []string{
+		"test/crds/crontab.yaml",
+	})
+
+	// unrelated to this test, but ensures that the agent quickly finds the
+	// Secret on the service cluster
+	dummyLabels := map[string]string{
+		"syncagent-e2e": "find-me",
+	}
+
+	// publish Crontabs with a related Secret (origin: service)
+	// RelatedResourceCleanup is NOT set, so it defaults to false
+	t.Log("Publishing CRDs…")
+	prCrontabs := &syncagentv1alpha1.PublishedResource{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "publish-crontabs",
+		},
+		Spec: syncagentv1alpha1.PublishedResourceSpec{
+			Resource: syncagentv1alpha1.SourceResourceDescriptor{
+				APIGroup: "example.com",
+				Version:  "v1",
+				Kind:     "CronTab",
+			},
+			Naming: &syncagentv1alpha1.ResourceNaming{
+				Name:      "{{ .Object.metadata.name }}",
+				Namespace: "synced-{{ .Object.metadata.namespace }}",
+			},
+			Projection: &syncagentv1alpha1.ResourceProjection{
+				Group: "kcp.example.com",
+			},
+			Related: []syncagentv1alpha1.RelatedResourceSpec{
+				{
+					Identifier: "credentials",
+					Origin:     syncagentv1alpha1.RelatedResourceOriginService,
+					Kind:       "Secret",
+					Object: syncagentv1alpha1.RelatedResourceObject{
+						RelatedResourceObjectSpec: syncagentv1alpha1.RelatedResourceObjectSpec{
+							Template: &syncagentv1alpha1.TemplateExpression{
+								Template: "my-credentials",
+							},
+						},
+					},
+					Watch: &syncagentv1alpha1.RelatedResourceWatch{
+						BySelector: &metav1.LabelSelector{
+							MatchLabels: dummyLabels,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	if err := envtestClient.Create(ctx, prCrontabs); err != nil {
+		t.Fatalf("Failed to create PublishedResource: %v", err)
+	}
+
+	// start the agent
+	utils.RunAgent(ctx, t, "bob", orgKubconfig, envtestKubeconfig, apiExportName, "")
+
+	// wait until the API is available
+	kcpClusterClient := utils.GetKcpAdminClusterClient(t)
+
+	teamClusterPath := logicalcluster.NewPath("root").Join(orgWorkspace).Join("team-1")
+	teamClient := kcpClusterClient.Cluster(teamClusterPath)
+
+	utils.WaitForBoundAPI(t, ctx, teamClient, schema.GroupVersionKind{
+		Group:   "kcp.example.com",
+		Version: "v1",
+		Kind:    "CronTab",
+	})
+
+	// Create a CronTab in kcp
+	t.Log("Creating CronTab in kcp…")
+	crontab := utils.YAMLToUnstructured(t, `
+apiVersion: kcp.example.com/v1
+kind: CronTab
+metadata:
+  namespace: default
+  name: my-crontab
+spec:
+  cronSpec: '* * *'
+  image: ubuntu:latest
+`)
+
+	crontab.SetLabels(dummyLabels)
+
+	if err := teamClient.Create(ctx, crontab); err != nil {
+		t.Fatalf("Failed to create CronTab in kcp: %v", err)
+	}
+
+	// Wait for the CronTab to be synced down to the service cluster
+	// This also ensures the namespace is created
+	t.Log("Waiting for CronTab to be synced to service cluster…")
+	serviceCrontab := &unstructured.Unstructured{}
+	serviceCrontab.SetAPIVersion("example.com/v1")
+	serviceCrontab.SetKind("CronTab")
+
+	err := wait.PollUntilContextTimeout(ctx, 500*time.Millisecond, 30*time.Second, false, func(ctx context.Context) (done bool, err error) {
+		return envtestClient.Get(ctx, types.NamespacedName{Namespace: "synced-default", Name: "my-crontab"}, serviceCrontab) == nil, nil
+	})
+	if err != nil {
+		t.Fatalf("CronTab was not synced to service cluster: %v", err)
+	}
+
+	t.Log("CronTab synced to service cluster")
+
+	// Create the related Secret on the service cluster
+	t.Log("Creating credential Secret on service cluster…")
+	serviceSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "my-credentials",
+			Namespace: "synced-default",
+		},
+		Data: map[string][]byte{
+			"password": []byte("hunter2"),
+		},
+		Type: corev1.SecretTypeOpaque,
+	}
+
+	if err := envtestClient.Create(ctx, serviceSecret); err != nil {
+		t.Fatalf("Failed to create Secret on service cluster: %v", err)
+	}
+
+	// Wait for the Secret to be synced up to kcp
+	t.Log("Waiting for Secret to be synced to kcp…")
+	kcpSecret := &corev1.Secret{}
+	err = wait.PollUntilContextTimeout(ctx, 500*time.Millisecond, 30*time.Second, false, func(ctx context.Context) (done bool, err error) {
+		return teamClient.Get(ctx, types.NamespacedName{Name: "my-credentials", Namespace: "default"}, kcpSecret) == nil, nil
+	})
+	if err != nil {
+		t.Fatalf("Secret was not synced to kcp: %v", err)
+	}
+
+	t.Log("Secret successfully synced to kcp")
+
+	// Delete the primary CronTab
+	t.Log("Deleting CronTab in kcp…")
+	if err := teamClient.Delete(ctx, crontab); err != nil {
+		t.Fatalf("Failed to delete CronTab: %v", err)
+	}
+
+	// Wait for CronTab to be fully deleted
+	err = wait.PollUntilContextTimeout(ctx, 500*time.Millisecond, 30*time.Second, false, func(ctx context.Context) (done bool, err error) {
+		err = teamClient.Get(ctx, ctrlruntimeclient.ObjectKeyFromObject(crontab), crontab)
+		return apierrors.IsNotFound(err), nil
+	})
+	if err != nil {
+		t.Fatalf("CronTab was not deleted: %v", err)
+	}
+
+	t.Log("CronTab deleted successfully")
+
+	// Verify that the related resources are NOT deleted on either side of the sync.
+
+	t.Log("Verifying that Secret in kcp remains…")
+	err = teamClient.Get(ctx, types.NamespacedName{Name: "my-credentials", Namespace: "default"}, kcpSecret)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			t.Error("Secret in kcp was deleted, but should have been preserved")
+		}
+		t.Errorf("Failed to get Secret in kcp: %v", err)
+	}
+
+	t.Log("Verifying that Secret on service cluster remains…")
+	err = envtestClient.Get(ctx, types.NamespacedName{Name: "my-credentials", Namespace: "synced-default"}, serviceSecret)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			t.Error("Secret on service cluster was deleted, but should have been preserved")
+		}
+		t.Errorf("Failed to get Secret on service cluster: %v", err)
+	}
+}
+
+func TestRelatedResourceCleanupEnabled(t *testing.T) {
+	const (
+		apiExportName = "kcp.example.com"
+		orgWorkspace  = "cleanup-enabled"
+	)
+
+	ctx := t.Context()
+	ctrlruntime.SetLogger(logr.Discard())
+
+	// setup a test environment in kcp
+	orgKubconfig := utils.CreateOrganization(t, ctx, orgWorkspace, apiExportName)
+
+	// start a service cluster
+	envtestKubeconfig, envtestClient, _ := utils.RunEnvtest(t, []string{
+		"test/crds/crontab.yaml",
+	})
+
+	// unrelated to this test, but ensures that the agent quickly finds the
+	// Secret on the service cluster
+	dummyLabels := map[string]string{
+		"syncagent-e2e": "find-me",
+	}
+
+	// publish Crontabs with a related Secret (origin: service)
+	// RelatedResourceCleanup is NOT set, so it defaults to false
+	t.Log("Publishing CRDs…")
+	prCrontabs := &syncagentv1alpha1.PublishedResource{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "publish-crontabs",
+		},
+		Spec: syncagentv1alpha1.PublishedResourceSpec{
+			Resource: syncagentv1alpha1.SourceResourceDescriptor{
+				APIGroup: "example.com",
+				Version:  "v1",
+				Kind:     "CronTab",
+			},
+			Naming: &syncagentv1alpha1.ResourceNaming{
+				Name:      "{{ .Object.metadata.name }}",
+				Namespace: "synced-{{ .Object.metadata.namespace }}",
+			},
+			Projection: &syncagentv1alpha1.ResourceProjection{
+				Group: "kcp.example.com",
+			},
+			Related: []syncagentv1alpha1.RelatedResourceSpec{
+				{
+					Identifier: "credentials",
+					Origin:     syncagentv1alpha1.RelatedResourceOriginService,
+					Kind:       "Secret",
+					Object: syncagentv1alpha1.RelatedResourceObject{
+						RelatedResourceObjectSpec: syncagentv1alpha1.RelatedResourceObjectSpec{
+							Template: &syncagentv1alpha1.TemplateExpression{
+								Template: "my-credentials",
+							},
+						},
+					},
+					Cleanup: true,
+					Watch: &syncagentv1alpha1.RelatedResourceWatch{
+						BySelector: &metav1.LabelSelector{
+							MatchLabels: dummyLabels,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	if err := envtestClient.Create(ctx, prCrontabs); err != nil {
+		t.Fatalf("Failed to create PublishedResource: %v", err)
+	}
+
+	// start the agent
+	utils.RunAgent(ctx, t, "bob", orgKubconfig, envtestKubeconfig, apiExportName, "")
+
+	// wait until the API is available
+	kcpClusterClient := utils.GetKcpAdminClusterClient(t)
+
+	teamClusterPath := logicalcluster.NewPath("root").Join(orgWorkspace).Join("team-1")
+	teamClient := kcpClusterClient.Cluster(teamClusterPath)
+
+	utils.WaitForBoundAPI(t, ctx, teamClient, schema.GroupVersionKind{
+		Group:   "kcp.example.com",
+		Version: "v1",
+		Kind:    "CronTab",
+	})
+
+	// Create a CronTab in kcp
+	t.Log("Creating CronTab in kcp…")
+	crontab := utils.YAMLToUnstructured(t, `
+apiVersion: kcp.example.com/v1
+kind: CronTab
+metadata:
+  namespace: default
+  name: my-crontab
+spec:
+  cronSpec: '* * *'
+  image: ubuntu:latest
+`)
+
+	crontab.SetLabels(dummyLabels)
+
+	if err := teamClient.Create(ctx, crontab); err != nil {
+		t.Fatalf("Failed to create CronTab in kcp: %v", err)
+	}
+
+	// Wait for the CronTab to be synced down to the service cluster
+	// This also ensures the namespace is created
+	t.Log("Waiting for CronTab to be synced to service cluster…")
+	serviceCrontab := &unstructured.Unstructured{}
+	serviceCrontab.SetAPIVersion("example.com/v1")
+	serviceCrontab.SetKind("CronTab")
+
+	err := wait.PollUntilContextTimeout(ctx, 500*time.Millisecond, 30*time.Second, false, func(ctx context.Context) (done bool, err error) {
+		return envtestClient.Get(ctx, types.NamespacedName{Namespace: "synced-default", Name: "my-crontab"}, serviceCrontab) == nil, nil
+	})
+	if err != nil {
+		t.Fatalf("CronTab was not synced to service cluster: %v", err)
+	}
+
+	t.Log("CronTab synced to service cluster")
+
+	// Create the related Secret on the service cluster
+	t.Log("Creating credential Secret on service cluster…")
+	serviceSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "my-credentials",
+			Namespace: "synced-default",
+		},
+		Data: map[string][]byte{
+			"password": []byte("hunter2"),
+		},
+		Type: corev1.SecretTypeOpaque,
+	}
+
+	if err := envtestClient.Create(ctx, serviceSecret); err != nil {
+		t.Fatalf("Failed to create Secret on service cluster: %v", err)
+	}
+
+	// Wait for the Secret to be synced up to kcp
+	t.Log("Waiting for Secret to be synced to kcp…")
+	kcpSecret := &corev1.Secret{}
+	err = wait.PollUntilContextTimeout(ctx, 500*time.Millisecond, 30*time.Second, false, func(ctx context.Context) (done bool, err error) {
+		return teamClient.Get(ctx, types.NamespacedName{Name: "my-credentials", Namespace: "default"}, kcpSecret) == nil, nil
+	})
+	if err != nil {
+		t.Fatalf("Secret was not synced to kcp: %v", err)
+	}
+
+	t.Log("Secret successfully synced to kcp")
+
+	// Delete the primary CronTab
+	t.Log("Deleting CronTab in kcp…")
+	if err := teamClient.Delete(ctx, crontab); err != nil {
+		t.Fatalf("Failed to delete CronTab: %v", err)
+	}
+
+	// Wait for CronTab to be fully deleted
+	err = wait.PollUntilContextTimeout(ctx, 500*time.Millisecond, 30*time.Second, false, func(ctx context.Context) (done bool, err error) {
+		err = teamClient.Get(ctx, ctrlruntimeclient.ObjectKeyFromObject(crontab), crontab)
+		return apierrors.IsNotFound(err), nil
+	})
+	if err != nil {
+		t.Fatalf("CronTab was not deleted: %v", err)
+	}
+
+	t.Log("CronTab deleted successfully")
+
+	// Verify that the related resources are deleted on the destination side.
+
+	t.Log("Verifying that Secret in kcp is deleted…")
+	err = teamClient.Get(ctx, types.NamespacedName{Name: "my-credentials", Namespace: "default"}, kcpSecret)
+	if err == nil {
+		t.Error("Secret in kcp was preserved, but should have been deleted")
+	} else if !apierrors.IsNotFound(err) {
+		t.Errorf("Failed to get Secret in kcp: %v", err)
+	}
+
+	t.Log("Verifying that Secret on service cluster remains…")
+	err = envtestClient.Get(ctx, types.NamespacedName{Name: "my-credentials", Namespace: "synced-default"}, serviceSecret)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			t.Error("Secret on service cluster was deleted, but should have been preserved")
+		}
+		t.Errorf("Failed to get Secret on service cluster: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
This adds a new option to each RelatedResource, allowing the admin to configure whether the created copies of such related resources should be deleted when the primary object is deleted. By default we don't do this, in case for example a Secret was synced from the service cluster to kcp and is integrated there into other automation: we wouldn't want to break that automation.

But in some scenarios it can make sense to clean up, and this is what this PR enables.

This PR also includes a small improvement to make the RR Watches work if the RR is still using `Kind` (i.e. GVK) instead of GVR.

## What Type of PR Is This?
/kind feature

## Related Issue(s)
Fixes #114

## Release Notes
```release-note
NONE
```
