### PR TITLE
Use the GroupVersion.Version instead of the resources' preferred version

### DIFF
--- a/internal/discovery/client.go
+++ b/internal/discovery/client.go
@@ -106,15 +106,14 @@ func (c *Client) RetrieveCRD(ctx context.Context, gk schema.GroupKind) (*apiexte
 			if subresource == "" {
 				resource = &res
 			} else {
-				list, ok := subresourcesPerVersion[res.Version]
+				list, ok := subresourcesPerVersion[gv.Version]
 				if !ok {
 					list = sets.New[string]()
 				}
 				list.Insert(subresource)
-				subresourcesPerVersion[res.Version] = list
+				subresourcesPerVersion[gv.Version] = list
 			}
 
-			// res.Version is also empty for built-in resources
 			availableVersions.Insert(gv.Version)
 		}
 	}

--- a/test/e2e/discovery/discovery_test.go
+++ b/test/e2e/discovery/discovery_test.go
@@ -35,11 +35,12 @@ import (
 
 func TestDiscoverSingleVersionCRD(t *testing.T) {
 	testcases := []struct {
-		name             string
-		crdFiles         []string
-		groupKind        schema.GroupKind
-		expectedVersions []string
-		expectedNames    apiextensionsv1.CustomResourceDefinitionNames
+		name                 string
+		crdFiles             []string
+		groupKind            schema.GroupKind
+		expectedVersions     []string
+		expectedNames        apiextensionsv1.CustomResourceDefinitionNames
+		expectedSubresources map[string]apiextensionsv1.CustomResourceSubresources
 	}{
 		{
 			name:             "get non-CRD resource",
@@ -89,6 +90,18 @@ func TestDiscoverSingleVersionCRD(t *testing.T) {
 				ListKind:   "HorizontalPodAutoscalerList",
 				Categories: []string{"all"},
 			},
+			expectedSubresources: map[string]apiextensionsv1.CustomResourceSubresources{
+				"v1": {
+					Status: &apiextensionsv1.CustomResourceSubresourceStatus{},
+					// envtest returns nil here instead of the real default value.
+					Scale: nil,
+				},
+				"v2": {
+					Status: &apiextensionsv1.CustomResourceSubresourceStatus{},
+					// envtest returns nil here instead of the real default value.
+					Scale: nil,
+				},
+			},
 		},
 	}
 
@@ -129,6 +142,18 @@ func TestDiscoverSingleVersionCRD(t *testing.T) {
 
 			if diff := cmp.Diff(testcase.expectedVersions, versions); diff != "" {
 				t.Errorf("Did not get expected CRD versions:\n\n%s", diff)
+			}
+
+			if testcase.expectedSubresources != nil {
+				gotSubresources := map[string]apiextensionsv1.CustomResourceSubresources{}
+				for _, v := range crd.Spec.Versions {
+					if v.Subresources != nil {
+						gotSubresources[v.Name] = *v.Subresources
+					}
+				}
+				if diff := cmp.Diff(testcase.expectedSubresources, gotSubresources); diff != "" {
+					t.Errorf("Did not get expected CRD subresources:\n\n%s", diff)
+				}
 			}
 		})
 	}


### PR DESCRIPTION

<!--
Thanks for creating a pull request!
If this is your first time, please make sure to review CONTRIBUTING.md.
-->

## Summary
<!--
Please provide a description that explains *why* your PR is changing something
in the codebase, and focus less on *what* you're changing. The following are
good questions to ask yourself when writing the PR summary:

* What are the problems you are trying to solve?
* What assumptions did you make when implementing your changes?
* Which workflows will be affected/improved by your change?
-->

APIResource.Version may be empty:
https://github.com/kubernetes/apimachinery/blob/6fa8dff7b19f13e310ef489972c8f394a9c185ad/pkg/apis/meta/v1/types.go#L1235-L1237

Additionally it reports the resources' preferred version, not the version it was listed for per APIResourceList.GroupVersion: https://github.com/kubernetes/apimachinery/blob/master/pkg/apis/meta/v1/types.go

I believe this is irrelevant in most cases however we hit this when using api-syncagent against resources provided by an aggregated API server, which does not fill the .Version on the resource.


## What Type of PR Is This?

/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind chore
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

## Related Issue(s)
Fixes #

## Release Notes
<!--
Please add a release note in the block below.
Leave NONE only if no user-facing changes are in this PR.
-->
```release-note
NONE
```
